### PR TITLE
Build issue - parent pom 1.12 does not exist 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>io.nats</groupId>
         <artifactId>nats-parent</artifactId>
-        <version>1.12-SNAPSHOT</version>
+        <version>1.13-SNAPSHOT</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
Local builds were failing because parent pom 1.12 does not exist in Sonatype.  Updating to 1.13 resolves this issue.