### PR TITLE
Disable snapshot deployment

### DIFF
--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -13,6 +13,7 @@ else
     echo "not on a tag -> keep snapshot version in pom.xml"
 fi
 
-mvn deploy --settings .travis/settings.xml -Pnats-release -Dskip.unit.tests=true -B
+# Temporarily disabled due to credential issues.
+# mvn deploy --settings .travis/settings.xml -Pnats-release -Dskip.unit.tests=true -B
 
 ${TRAVIS_BUILD_DIR}/.travis/publish-javadoc.sh


### PR DESCRIPTION
Snapshot deployment will be disabled until credential issues with maven are resolved.