### PR TITLE
clean up any poll Threads on subscription close

### DIFF
--- a/src/main/java/io/nats/client/SubscriptionImpl.java
+++ b/src/main/java/io/nats/client/SubscriptionImpl.java
@@ -162,6 +162,10 @@ abstract class SubscriptionImpl implements Subscription {
             // Just log and ignore. This is for AutoCloseable.
             logger.debug("Exception while calling unsubscribe from AutoCloseable.close()", e);
         }
+        mu.lock();
+        this.closed = true;
+        this.pCond.signalAll();
+        mu.unlock();
     }
 
     long getSid() {


### PR DESCRIPTION
- sets the subscription `closed` instance var
- signals any waiting poll Threads

fix for https://github.com/nats-io/java-nats/issues/111