### PR TITLE
Clarify the reply example in README.md a bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ sub.unsubscribe();
 msg = nc.request("help", "help me".getBytes(), 10000);
 
 // Replies
-nc.subscribe("help", reply -> {
+nc.subscribe("help", message -> {
     try {
-        nc.publish(reply.getReplyTo(), "I can help!".getBytes());
+        nc.publish(message.getReplyTo(), "I can help!".getBytes());
     } catch (Exception e) {
         e.printStackTrace();
     }


### PR DESCRIPTION
Parameter name reply was IMO nonoptimal since that parameter contains the request message.