### PR TITLE
Configurable async subscriber threading model

### DIFF
--- a/src/main/java/io/nats/client/Nats.java
+++ b/src/main/java/io/nats/client/Nats.java
@@ -11,6 +11,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Executors;
 
 /**
  * <img src="{@docRoot}/resources/large-logo.png" alt="NATS logo">
@@ -379,6 +380,7 @@ public final class Nats {
 
     static final String PROP_PROPERTIES_FILENAME = "jnats.properties";
     static final String PROP_CLIENT_VERSION = "client.version";
+    static final String PROP_SUBSCRIPTION_CONCURRENCY = "subscription.concurrency";
 
     // Server error strings
     protected static final String SERVER_ERR_PARSER = "'Parser Error'";
@@ -439,7 +441,7 @@ public final class Nats {
      * @return the default {@link Options}
      */
     public static Options defaultOptions() {
-        return new Options.Builder().build();
+        return new Options.Builder().subscriptionDispatchPool(Executors.newFixedThreadPool(4)).build();
     }
 
     static List<URI> processUrlString(String url) {

--- a/src/main/java/io/nats/client/Options.java
+++ b/src/main/java/io/nats/client/Options.java
@@ -313,7 +313,7 @@ public class Options {
         return disconnectedCb;
     }
     
-    public ExecutorService getSubscriptionDispatch() {
+    public ExecutorService getSubscriptionDispatchPool() {
         return subscriptionDispatchPool;
     }
 

--- a/src/main/java/io/nats/client/Options.java
+++ b/src/main/java/io/nats/client/Options.java
@@ -44,6 +44,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLContext;
 
@@ -89,6 +90,8 @@ public class Options {
     public ReconnectedCallback reconnectedCb;
     public ExceptionHandler asyncErrorCb;
 
+    ExecutorService subscriptionDispatchPool;
+
     // Size of the backing ByteArrayOutputStream buffer during reconnect.
     // Once this has been exhausted publish operations will error.
     final int reconnectBufSize;
@@ -131,7 +134,7 @@ public class Options {
         this.closedCb = builder.closedCb;
         this.reconnectedCb = builder.reconnectedCb;
         this.asyncErrorCb = builder.asyncErrorCb;
-
+        this.subscriptionDispatchPool = builder.subscriptionDispatchPool;
     }
 
     @Override
@@ -309,6 +312,10 @@ public class Options {
     public DisconnectedCallback getDisconnectedCallback() {
         return disconnectedCb;
     }
+    
+    public ExecutorService getSubscriptionDispatch() {
+        return subscriptionDispatchPool;
+    }
 
     // public void addCertificate(X509Certificate cert) {
     // if (cert==null)
@@ -362,6 +369,7 @@ public class Options {
         ClosedCallback closedCb;
         ReconnectedCallback reconnectedCb;
         ExceptionHandler asyncErrorCb;
+        ExecutorService subscriptionDispatchPool;
 
         /**
          * Constructs a {@link Builder} instance based on the supplied {@link Options} instance.
@@ -641,6 +649,11 @@ public class Options {
             if (sslContext != null) {
                 this.secure = true;
             }
+            return this;
+        }
+
+        public Builder subscriptionDispatchPool(ExecutorService threadPool) {
+            this.subscriptionDispatchPool = threadPool;
             return this;
         }
 

--- a/src/test/java/io/nats/client/ConnectionImplTest.java
+++ b/src/test/java/io/nats/client/ConnectionImplTest.java
@@ -40,7 +40,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -1492,7 +1491,7 @@ public class ConnectionImplTest {
             sub.pCond = mock(Condition.class);
 
             parser.ps.ma.size = length;
-            c.processMsg(data, offset, length);
+            c.processMsg(data, offset, length).get();
 
             // InMsgs should be incremented by 1
             assertEquals(1, c.getStats().getInMsgs());
@@ -1531,7 +1530,7 @@ public class ConnectionImplTest {
             assertEquals(1, sub.getPendingMsgsLimit());
             assertEquals(1, sub.pMsgs);
 
-            c.processMsg(data, offset, length);
+            c.processMsg(data, offset, length).get();
 
             // InMsgs should be incremented by 1, even if the sub stats don't increase
             assertEquals(1, c.getStats().getInMsgs());
@@ -1567,7 +1566,7 @@ public class ConnectionImplTest {
 
             sub.pCond = mock(Condition.class);
 
-            c.processMsg(data, offset, length);
+            c.processMsg(data, offset, length).get();
 
             // InMsgs should be incremented by 1, even if the sub stats don't increase
             assertEquals(1, c.getStats().getInMsgs());


### PR DESCRIPTION
Addresses nats-io/java-nats#113 - configurable concurrency for async subscription dispatch, as follows:

 * Adds `Options.Builder.subscriptionDispatchPool ( ExecutorService )`
 * Adds `Options.getSubscriptionDispatchPool()`
 * Adds `Nats.PROP_SUBSCRIPTION_CONCURRENCY = "subscription.concurrency"`

with the following behavior:

1.  If no executor and subscription concurrency not set, behavior is same as before
2.  If subscription concurrency is set, `java.util.concurrent.Executors.newFixedThreadPool()` is called with the property value
3.  If an `ExecutorService` was set in the connection options that is used;  if both that and the subscription concurrency property are set, the provided `ExecutorService` wins.

All tests pass with and without the patch;  I left it on in `ConnectionImplTest`.

One thing that is not obvious is whether the `Runnable` that invokes the subscriber needs to take `mu.lock()` - to err on the side of correctness I did, but probably better liveness can be had if that can be avoided, since it seems to be used everywhere.  A better variable name than `mu` might help contributors figure out *what* it locks :-)
