### PR TITLE
Round 2 of pooled delivery of asynchronous subscriptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ hs_err_pid*
 # NATS stuff
 gnatsd.log
 *.csv
+/nbproject/
+

--- a/pom.xml
+++ b/pom.xml
@@ -268,6 +268,7 @@
                     <!-- Skips unit tests if the value of skip.unit.tests 
                         property is true -->
                     <skipTests>${skip.unit.tests}</skipTests>
+                    <trimStackTrace>false</trimStackTrace>
                     <!-- Excludes integration tests when unit tests are run. -->
                     <excludes>
                         <exclude>**/IT*.java</exclude>
@@ -306,6 +307,7 @@
                             <goal>verify</goal>
                         </goals>
                         <configuration>
+                            <trimStackTrace>false</trimStackTrace>
                             <!-- Sets the VM argument line used when integration 
                                 tests are run. -->
                             <argLine>${failsafeArgLine}</argLine>

--- a/pom.xml
+++ b/pom.xml
@@ -272,6 +272,11 @@
                     <excludes>
                         <exclude>**/IT*.java</exclude>
                     </excludes>
+                    <systemPropertyVariables>
+                        <forkNumber>${surefire.forkNumber}</forkNumber>
+                        <unit.test>true</unit.test>
+                    </systemPropertyVariables>
+                    
                 </configuration>
                 <executions>
                     <execution>

--- a/src/it/java/io/nats/client/ITAsyncDeliveryTest.java
+++ b/src/it/java/io/nats/client/ITAsyncDeliveryTest.java
@@ -1,0 +1,295 @@
+package io.nats.client;
+
+import io.nats.client.AsyncDeliveryQueueTest.SubscriberKey;
+import io.nats.client.IntegrationTest;
+import static io.nats.client.UnitTestUtilities.runDefaultServer;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.After;
+import org.junit.AfterClass;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/*
+ * The MIT License
+ *
+ * Copyright 2017 Apcera, Inc..
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+/**
+ *
+ * @author Tim Boudreau
+ */
+@Category(IntegrationTest.class)
+public class ITAsyncDeliveryTest {
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+    }
+
+    @Before
+    public void setUp() throws Exception {
+
+    }
+
+    @After
+    public void tearDown() throws Exception {
+    }
+
+    @Test(timeout = 480000)
+    public void testThreadPerSubscription() throws Throwable {
+        boolean batched = false;
+        System.out.println("\n\n\n**************** testThreadPerSubscription *********************\n\n\n");
+        EH errors = new EH();
+        try (NatsServer srv = runDefaultServer()) {
+            try (ConnectionImpl conn = (ConnectionImpl) connection(batched, errors)) {
+                String msgPrefix = batched ? "batched-mode " : "thread-per-subscriber ";
+                testAsyncDelivery(conn, msgPrefix, errors);
+                errors.rethrow();
+            }
+        }
+    }
+
+    @Test(timeout = 480000)
+    public void testBatchedSubscriptions() throws Throwable {
+        boolean batched = true;
+        System.out.println("\n\n\n**************** testBatchedSubscriptions *********************\n\n\n");
+        EH errors = new EH();
+        try (NatsServer srv = runDefaultServer()) {
+            try (ConnectionImpl conn = (ConnectionImpl) connection(batched, errors)) {
+                String msgPrefix = batched ? "batched-mode " : "thread-per-subscriber ";
+                testAsyncDelivery(conn, msgPrefix, errors);
+                errors.rethrow();
+            }
+        }
+    }
+
+    static class EH implements ExceptionHandler {
+
+        Throwable thrown = null;
+
+        synchronized void rethrow() throws Throwable {
+            if (thrown != null) {
+                throw thrown;
+            }
+        }
+
+        volatile Thread testThread;
+
+        void pickUpTestThread() {
+            testThread = Thread.currentThread();
+        }
+
+        @Override
+        public synchronized void onException(NATSException ex) {
+            Throwable t = ex;
+            while (t.getCause() != null) {
+                t = t.getCause();
+                if (t.getCause() == null) {
+                    break;
+                }
+            }
+            if (thrown != null) {
+                thrown.addSuppressed(t);
+            } else {
+                thrown = t;
+            }
+            if (testThread != null) {
+                testThread.interrupt();
+            }
+        }
+
+    }
+
+    static Connection connection(boolean batched, ExceptionHandler errors) throws IOException {
+        Options.Builder builder = new Options.Builder().errorCb(errors);
+        if (batched) {
+            // Intentionally have more threads than channels, so there is the
+            // possibility to have two threads get a batch of messages at the
+            // same time and delver them out of sequence - this means we actually
+            // test the thread affinity code in AsyncDispatchQueue.
+            builder.subscriptionDispatchPool(Executors.newFixedThreadPool(16));
+        }
+        return builder.build().connect();
+    }
+
+    final AsyncDeliveryQueueTest.SubscriberKey[] keys = new SubscriberKey[]{
+        AsyncDeliveryQueueTest.keyA,
+        AsyncDeliveryQueueTest.keyB,
+        AsyncDeliveryQueueTest.keyC,
+        AsyncDeliveryQueueTest.keyD,
+        AsyncDeliveryQueueTest.keyE,
+        AsyncDeliveryQueueTest.keyF,
+        AsyncDeliveryQueueTest.keyG,};
+
+    void testAsyncDelivery(Connection conn, String msgPrefix, EH errors) throws Throwable {
+        System.out.println("TEST DELIVERY " + msgPrefix);
+        List<Message> messages = new CopyOnWriteArrayList<>();
+        List<MsgHandler> handlers = new ArrayList<>();
+        int numMessagesPerKey = 151;
+        int batchSize = 31;
+        int totalPerKey = numMessagesPerKey * batchSize;
+        for (int i = 0; i < numMessagesPerKey; i++) {
+            for (SubscriberKey key : keys) {
+                messages.addAll(AsyncDeliveryQueueTest.messageBatch(key, batchSize));
+            }
+        }
+        CountDownLatch allProcessed = new CountDownLatch(totalPerKey);
+        for (SubscriberKey key : keys) {
+            MsgHandler mh = new MsgHandler(msgPrefix, allProcessed, key);
+            handlers.add(mh);
+            conn.subscribe(key.name, mh);
+        }
+        Thread.sleep(300); // XXX messagehandler really needs a hook to identify that
+        // it is being used as a receiver of messages - i.e. the library has set up
+        // threads, etc.
+        for (int i = 0; i < messages.size(); i++) {
+            conn.publish(messages.get(i));
+            // Occasionally get out of the way
+            if (i % 31 == 0) {
+                Thread.sleep(50);
+            }
+            if (i % 300 == 0) {
+                System.out.println("...published " + i + " so far...");
+            }
+            if (Thread.interrupted()) {
+                errors.rethrow();
+            }
+        }
+        System.out.println("Published " + messages.size() + " messages");
+        allProcessed.await(120, TimeUnit.SECONDS);
+        errors.rethrow();
+        Thread.sleep(1200);
+        System.out.println("Exit wait on subscribers");
+        for (MsgHandler h : handlers) {
+            System.out.println(h.sub + " RECEIVED " + h.deliveredCount());
+        }
+
+        int total = 0;
+        Collections.reverse(handlers);
+        for (MsgHandler h : handlers) {
+            int count = h.deliveredCount();
+            total += count;
+            h.assertArrivedInOrder();
+        }
+        for (MsgHandler h : handlers) {
+            h.assertAllMessagesDelivered(totalPerKey, messages);
+        }
+        assertEquals(messages.size(), total);
+    }
+
+    static final AtomicInteger TOTAL_ORDER = new AtomicInteger();
+
+    static final class MsgHandler implements MessageHandler {
+
+        private final String pfx;
+
+        private final CountDownLatch latch;
+        private final Map<Integer, Message> order = new ConcurrentHashMap<>();
+
+        String sub;
+        private final SubscriberKey key;
+
+        public MsgHandler(String pfx, CountDownLatch latch, SubscriberKey key) {
+            this.pfx = pfx;
+            this.latch = latch;
+            this.key = key;
+        }
+
+        @Override
+        public void onMessage(Message msg) {
+            if (order.isEmpty()) {
+                System.out.println(pfx + "Received first: " + msg.getSubject());
+            }
+            if (sub != null) {
+                // Error handler will catch
+                assertEquals(sub, msg.getSubject());
+            }
+            sub = msg.getSubject();
+            order.put(TOTAL_ORDER.getAndIncrement(), msg);
+            latch.countDown();
+            if (order.size() % 200 == 0) {
+                System.out.println(pfx + "Received " + order.size() + " for " + msg.getSubject());
+            }
+        }
+
+        int deliveredCount() {
+            return order.size();
+        }
+
+        void assertAllMessagesDelivered(int expectedCount, List<Message> allMessages) {
+            // Convert messages to a wrapper class that implements comparable on the byte payload (which is
+            // just a long stored in a byte array) and implements proper equals/hashcode.
+            List<AsyncDeliveryQueueTest.ComparableMessageWrapper> missing = new ArrayList<>();
+            List<AsyncDeliveryQueueTest.ComparableMessageWrapper> wrappers = AsyncDeliveryQueueTest.toWrappers(allMessages);
+            Set<AsyncDeliveryQueueTest.ComparableMessageWrapper> myWrappers
+                    = new LinkedHashSet<>(AsyncDeliveryQueueTest.toWrappers(new ArrayList<>(order.values())));
+
+            int totalForSubject = 0;
+            for (AsyncDeliveryQueueTest.ComparableMessageWrapper m : wrappers) {
+                if (key.name.equals(m.message.getSubject())) {
+                    totalForSubject++;
+                    if (!myWrappers.contains(m)) {
+                        missing.add(m);
+                    }
+                }
+            }
+            if (!missing.isEmpty()) {
+                Collections.sort(missing);
+                fail(pfx + sub + " missing messages " + missing);
+            }
+            assertEquals("Message counts differ", totalForSubject, myWrappers.size());
+        }
+
+        void assertArrivedInOrder() {
+            List<Message> arrivalOrder = new ArrayList<>();
+            collectInOrder(arrivalOrder);
+            AsyncDeliveryQueueTest.assertListSorted(pfx + ": Messages arrived out of order", arrivalOrder);
+        }
+
+        void collectInOrder(List<? super Message> into) {
+            List<Integer> orderedKeys = new ArrayList<>(order.keySet());
+            Collections.sort(orderedKeys);
+            for (Integer key : orderedKeys) {
+                into.add(order.get(key));
+            }
+        }
+    }
+
+}

--- a/src/it/java/io/nats/client/ITSubscriptionTest.java
+++ b/src/it/java/io/nats/client/ITSubscriptionTest.java
@@ -684,6 +684,12 @@ public class ITSubscriptionTest {
 
                     // Make sure dropped stats is correct
                     int dropped = toSend - limit;
+                    // XXX - with async subcriptions, the number we get here is going to
+                    // be dependent on the behavior of the thread scheduler - messages
+                    // are retrieved in batches, and what a batch contains is timing-dependent
+                    // In this test, we may be blocked in the blocker, but the maximum
+                    // is tested and the list of messages to deliver trimmed before *batch* delivery
+                    // commences
                     assertEquals(String.format("Expected dropped to be %d, but was actually %d\n",
                             dropped, sub.getDropped()), dropped, sub.getDropped());
                     int ae = aeCalled.get();

--- a/src/main/java/io/nats/client/AsyncDeliveryQueue.java
+++ b/src/main/java/io/nats/client/AsyncDeliveryQueue.java
@@ -1,0 +1,384 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2017 Apcera, Inc..
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.nats.client;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Asynchronous queue for delivering messages to async subscribers. Uses atomic
+ * operations on ConcurrentHashMap in place of global locks where possible.
+ *
+ * @author Tim Boudreau
+ */
+final class AsyncDeliveryQueue {
+
+    private final ConcurrentMap<Long, Messages> messagesForSubscriber;
+    private final Map<Long, Thread> threadAffinity;
+
+    AsyncDeliveryQueue() {
+        this(10000, 0.75F, 16);
+    }
+
+    AsyncDeliveryQueue(int initialSize, float loadFactor, int concurrency) {
+        messagesForSubscriber = new ConcurrentHashMap<>(initialSize, loadFactor, concurrency);
+        threadAffinity = new ConcurrentHashMap<>(initialSize, loadFactor, concurrency);
+    }
+
+    /**
+     * Add a message mapped to a subcriber id
+     *
+     * @param subscriberId The subscriber id
+     * @param message The message
+     */
+    void add(long subscriberId, Message message) {
+        addIfNotNull(messagesForSubscriber.putIfAbsent(subscriberId, new Messages().add(message)), message);
+        signalOneThread();
+    }
+
+    /**
+     * Pre-create a messages queue for a subscriber id, ensuring that contains()
+     * tests for that id will return true.
+     *
+     * @param subscriberId The subscriber ide
+     * @return True if the subscriber id was not already present
+     */
+    boolean touch(long subscriberId) {
+        return messagesForSubscriber.putIfAbsent(subscriberId, new Messages()) == null;
+    }
+
+    /**
+     * Remove a subscriber id
+     *
+     * @param subscriberId The id
+     */
+    void remove(long subscriberId) {
+        messagesForSubscriber.remove(subscriberId);
+        threadAffinity.remove(subscriberId);
+    }
+
+    /**
+     * Remove a susbcriber id, retrieving any remaining messages
+     *
+     * @param subscriberId The id
+     * @return A list of messages
+     */
+    List<Message> removeAndCollect(long subscriberId) {
+        Messages m = messagesForSubscriber.remove(subscriberId);
+        threadAffinity.remove(subscriberId);
+        return m.drain(new long[1]);
+    }
+
+    /**
+     * Test if the subscriber id is present.
+     *
+     * @param subscriberId The subscriber id
+     * @return true if it is present
+     */
+    boolean contains(long subscriberId) {
+        return messagesForSubscriber.containsKey(subscriberId);
+    }
+
+    private void addIfNotNull(Messages msgs, Message message) {
+        if (msgs != null) {
+            msgs.add(message);
+        }
+    }
+
+    public int get(List<? super MessageBatch> into, long timeout, TimeUnit unit) throws InterruptedException {
+        // If messages immediately available, return them without waiting
+        if (drain(into) > 0) {
+            return into.size();
+        }
+        // wait for signal
+        synchronized (this) {
+            wait(unit.toMillis(timeout));
+        }
+        // And drain
+        return drain(into);
+    }
+
+    public int get(List<? super MessageBatch> into) throws InterruptedException {
+        // If messages immediately available, return them without waiting
+        if (drain(into) > 0) {
+            return into.size();
+        }
+        // wait for signal
+        while (into.isEmpty()) {
+            // It *is* possible to have messages waiting which we will never
+            // be signalled for, so this needs to be a slow busywait.  That
+            // should only happen under heavy contention.
+            get(into, 250, TimeUnit.MILLISECONDS);
+        }
+        return into.size();
+    }
+
+    public void clear() {
+        synchronized (this) {
+            notifyAll();
+        }
+        // Give a chance at message collection
+        Thread.yield();
+        messagesForSubscriber.clear();
+        threadAffinity.clear();
+    }
+
+    private int drain(List<? super MessageBatch> batch) {
+        int result = 0;
+        boolean resignal = false;
+        Thread currentThread = Thread.currentThread();
+        for (Map.Entry<Long, Messages> e : messagesForSubscriber.entrySet()) {
+            // Ensure that only this thread can read messages for this key, until
+            // the batch for that key is closed.
+            Thread threadForKey = threadAffinity.putIfAbsent(e.getKey(), currentThread);
+            if (threadForKey != null && threadForKey != currentThread) {
+                // Some other thread is currently dispatching messages for
+                // this subscriber, so we won't take any
+                // But note it and signal another thread (would be nicer to have a
+                // per-long condition so we could signal the exact thread, but you can't have
+                // atomic operations across two maps without a lock)
+                resignal |= e.getValue().count > 0;
+                continue;
+            }
+            // Atomically swap in a new Messages, *if* the messages object returned by
+            // e.getValue() is still the one actually in the map - another thread may
+            // have been in this method concurrently and claimed it, in which case we
+            // skip this key - another thread already has its messages
+            if (messagesForSubscriber.replace(e.getKey(), e.getValue(), new Messages())) {
+                long[] totalBytes = new long[1];
+                List<Message> msgs = e.getValue().drain(totalBytes);
+                if (!msgs.isEmpty()) {
+                    result += msgs.size();
+                    batch.add(new MessageBatchImpl(e.getKey(), msgs, currentThread, totalBytes[0]));
+                } else {
+                    threadAffinity.remove(e.getKey());
+                }
+            }
+        }
+        // Note that resignal is best-effort - we cannot guarantee that another
+        // thread did not add something not reflected in messagesForSubscriber.entrySet
+        // while we were iterating it.  Hence the busywait rather than full wait
+        // in wait()
+        if (resignal) {
+            signalOneThread();
+        }
+        return result;
+    }
+
+    private void signalOneThread() {
+        synchronized (this) {
+            notify();
+        }
+    }
+
+    int estimatedSize() {
+        int result = 0;
+        for (Messages m : messagesForSubscriber.values()) {
+            result += m.count;
+        }
+        return result;
+    }
+
+    Set<Long> lockedKeys() {
+        return threadAffinity.keySet();
+    }
+
+    /**
+     * Wrapper for a list of messages, mapped to subscriber ID. It is *critical*
+     * to call close() on every batch returned. The call is idempotent.
+     */
+    interface MessageBatch extends Iterable<Message>, AutoCloseable {
+
+        /**
+         * The subscriber id this set of messages targets.
+         *
+         * @return The id
+         */
+        long subscriberId();
+
+        /**
+         * The number of messages retrievd (may be 0).
+         *
+         * @return The size
+         */
+        int size();
+
+        /**
+         * The total number of bytes in the data arrays of all messages in this
+         * batch.
+         *
+         * @return The total number of bytes
+         */
+        long totalBytes();
+
+        /**
+         * Close this message batch, allowing other threads to enter and
+         * retrieve messages for this subscriber id. If not called, messages may
+         * be queued indefinitely..
+         */
+        @Override
+        void close();
+
+        List<Message> toList();
+    }
+
+    private final class MessageBatchImpl implements MessageBatch {
+
+        private final List<Message> messages;
+        private final long subscriberId;
+        private final Thread creatingThread;
+        private volatile boolean closed;
+        private final long totalBytes;
+
+        MessageBatchImpl(long subscriberId, List<Message> messages, Thread creatingThread, long totalBytes) {
+            this.messages = messages;
+            this.subscriberId = subscriberId;
+            this.creatingThread = creatingThread;
+            this.totalBytes = totalBytes;
+        }
+
+        @Override
+        public long subscriberId() {
+            return subscriberId;
+        }
+
+        @Override
+        public Iterator<Message> iterator() {
+            return messages.iterator();
+        }
+
+        @Override
+        public int size() {
+            return messages.size();
+        }
+
+        @Override
+        public void close() {
+            boolean wasClosed = closed;
+            closed = true;
+            // Ensure we don't remove a the wrong thread in the case close() is
+            // not called from the same thread we have here
+            if (!wasClosed && threadAffinity.get(subscriberId) == creatingThread) {
+                threadAffinity.remove(subscriberId);
+            }
+        }
+
+        @Override
+        public long totalBytes() {
+            return totalBytes;
+        }
+
+        @Override
+        public List<Message> toList() {
+            return messages;
+        }
+
+        public String toString() {
+            return "MessageBatch for " + subscriberId() + " with " + messages.size() + " messages, total bytes " + totalBytes();
+        }
+    }
+
+    static final class Messages {
+
+        // A basic linked list structure, where the head is found by
+        // iterating backwards
+        MessageEntry tail;
+        // Safe for atomic reads without a lock
+        private volatile int count;
+
+        // Using plain synchronization here - a java.util.concurrent lock
+        // doesn't buy us anything;  and we create these frequently and throw
+        // them away, to have a new value if needed for atomic operations,
+        // so the cheaper construction is, the better, and you already
+        // get a synchronization monitor with every Java object
+        public Messages add(Message message) {
+            synchronized (this) {
+                count++;
+                // Replace the tail
+                if (tail == null) {
+                    tail = new MessageEntry(null, message);
+                } else {
+                    tail = new MessageEntry(tail, message);
+                }
+            }
+            return this;
+        }
+
+        public List<Message> drain(long[] totalBytes) {
+            assert totalBytes != null && totalBytes.length == 1;
+            if (count == 0) {
+                return Collections.emptyList();
+            }
+            // Do the minimal amount under the lock
+            MessageEntry oldTail;
+            synchronized (this) {
+                oldTail = tail;
+                count = 0;
+                tail = null;
+            }
+            // Populate the list iterating backwards from the tail
+            if (oldTail != null) {
+                if (oldTail.prev == null) {
+                    if (oldTail.message.getData() != null) {
+                        totalBytes[0] = oldTail.message.getData().length;
+                    }
+                    return Collections.singletonList(oldTail.message);
+                }
+                List<Message> all = new LinkedList<>();
+                oldTail.drainTo(all, totalBytes);
+                return all;
+            }
+            return Collections.emptyList();
+        }
+
+        static final class MessageEntry {
+
+            private MessageEntry prev;
+            private Message message;
+
+            public MessageEntry(MessageEntry prev, Message message) {
+                this.prev = prev;
+                this.message = message;
+            }
+
+            void drainTo(List<? super Message> messages, long[] totalBytes) {
+                MessageEntry e = this;
+                while (e != null) {
+                    messages.add(0, e.message);
+                    if (e.message.getData() != null) {
+                        totalBytes[0] += e.message.getData().length;
+                    }
+                    e = e.prev;
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/io/nats/client/AsyncDeliveryQueue.java
+++ b/src/main/java/io/nats/client/AsyncDeliveryQueue.java
@@ -24,33 +24,43 @@
 package io.nats.client;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLongArray;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+import java.util.function.UnaryOperator;
 
 /**
- * Asynchronous queue for delivering messages to async subscribers. Uses atomic
- * operations on ConcurrentHashMap in place of global locks where possible.
+ * Asynchronous queue for delivering messages to async subscribers.
+ * Uses AtomicReferenceArrays rather than traditional locks to manage
+ * concurrency.  Internally, manages a list of such arrays - since
+ * subscriber ids increase monotonically, despite the fact that they are
+ * long-indexed, the common case is a fairly small number, the array
+ * offset can be the index mapping.
  *
  * @author Tim Boudreau
  */
 final class AsyncDeliveryQueue {
 
-    private final ConcurrentMap<Long, Messages> messagesForSubscriber;
-    private final Map<Long, Thread> threadAffinity;
+    private final int arraySize;
+    private final List<AtomicReferenceArray<Messages>> arrays = new CopyOnWriteArrayList<>();
+    private final List<AtomicLongArray> threads = new CopyOnWriteArrayList<>();
 
     AsyncDeliveryQueue() {
-        this(10000, 0.75F, 16);
+        this(64);
     }
 
-    AsyncDeliveryQueue(int initialSize, float loadFactor, int concurrency) {
-        messagesForSubscriber = new ConcurrentHashMap<>(initialSize, loadFactor, concurrency);
-        threadAffinity = new ConcurrentHashMap<>(initialSize, loadFactor, concurrency);
+    AsyncDeliveryQueue(int arraySize) {
+        if (arraySize <= 0) {
+            throw new IllegalStateException("Invalid array size " + arraySize);
+        }
+        this.arraySize = arraySize;
     }
 
     /**
@@ -59,31 +69,75 @@ final class AsyncDeliveryQueue {
      * @param subscriberId The subscriber id
      * @param message The message
      */
-    synchronized void add(long subscriberId, Message message) {
-        addIfNotNull(messagesForSubscriber.putIfAbsent(subscriberId, new Messages().add(message)), message);
+    void add(long subscriberId, Message msg) {
+        int index = (int) (subscriberId / arraySize);
+        int offset = (int) (subscriberId % arraySize);
+        if (index >= arrays.size()) {
+            // Intentional double-checked locking here - we need
+            // an atomic size check + possible add in one shot
+            synchronized (arrays) {
+                if (index >= arrays.size()) {
+                    Messages nue = new Messages(msg);
+                    // Create a new array to contain messages for subscriberIds
+                    // starting at arrays.size() * arraySize
+                    AtomicReferenceArray<Messages> arr = new AtomicReferenceArray<>(arraySize);
+                    // Create a new long array to hold the thread id of any thread
+                    // that has exclusive claim on a particular subscriber id because
+                    // it is delivering messages for it (this state is cleared in
+                    // MessageBatch.close()).
+                    threads.add(new AtomicLongArray(arraySize));
+                    // Pre-populate it - the array must always contain a queue
+                    // ready to receive messages - the queues are lightweight
+                    for (int i = 0; i < arraySize; i++) {
+                        if (i == offset) {
+                            arr.set(i, nue);
+                        } else {
+                            arr.set(i, new Messages());
+                        }
+                    }
+                    arrays.add(arr);
+                    return;
+                }
+            }
+        }
+        AtomicReferenceArray<Messages> array = arrays.get(index);
+        array.get(offset).add(msg);
         signalOneThread();
     }
 
     /**
-     * Remove a subscriber id
+     * Remove a subscriber id.  Clears any pending mesesages
+     * (an entry remains).
      *
      * @param subscriberId The id
      */
     void remove(long subscriberId) {
-        messagesForSubscriber.remove(subscriberId);
-        threadAffinity.remove(subscriberId);
+        int index = (int) (subscriberId / arraySize);
+        int offset = (int) (subscriberId % arraySize);
+        if (index < arrays.size()) {
+            arrays.get(index).set(offset, new Messages());
+        }
+        threads.get(index).set(offset, 0L);
     }
 
     /**
-     * Remove a susbcriber id, retrieving any remaining messages
+     * Remove a susbcriber id, retrieving any remaining messages.
+     * Clears any pending mesesages (an entry remains).
      *
      * @param subscriberId The id
      * @return A list of messages
      */
     List<Message> removeAndCollect(long subscriberId) {
-        Messages m = messagesForSubscriber.remove(subscriberId);
-        threadAffinity.remove(subscriberId);
-        return m.drain(new long[1]);
+        int index = (int) (subscriberId / arraySize);
+        int offset = (int) (subscriberId % arraySize);
+        threads.get(index).set(offset, 0L);
+        if (index < arrays.size()) {
+            Messages old = arrays.get(index).getAndSet(offset, new Messages());
+            if (old != null) {
+                return old.drain(new long[1]);
+            }
+        }
+        return Collections.emptyList();
     }
 
     /**
@@ -92,16 +146,27 @@ final class AsyncDeliveryQueue {
      * @param subscriberId The subscriber id
      * @return true if it is present
      */
-    boolean contains(long subscriberId) {
-        return messagesForSubscriber.containsKey(subscriberId);
-    }
-
-    private void addIfNotNull(Messages msgs, Message message) {
-        if (msgs != null) {
-            msgs.add(message);
+    boolean containsMessagesFor(long subscriberId) {
+        int index = (int) (subscriberId / arraySize);
+        int offset = (int) (subscriberId % arraySize);
+        if (index < arrays.size()) {
+            Messages msgs = arrays.get(index).get(offset);
+            return msgs != null && !msgs.isEmpty();
         }
+        return false;
     }
 
+    /**
+     * Fetch messages, blocking for the specified timeout while waiting
+     * for them.
+     *
+     * @param into A list to put batches of messages into
+     * @param timeout The timeout
+     * @param unit The timeout time unit
+     * @return The total number of <i>Messages</i> retrieved in all
+     * MessageBatches added to the list
+     * @throws InterruptedException If the thread pool is shut down
+     */
     public int get(List<? super MessageBatch> into, long timeout, TimeUnit unit) throws InterruptedException {
         // If messages immediately available, return them without waiting
         if (drain(into) > 0) {
@@ -115,17 +180,25 @@ final class AsyncDeliveryQueue {
         return drain(into);
     }
 
+    /**
+     * Fetch messages, blocking until messages are available.
+     *
+     * @param into A list to put batches of messages into
+     * @param timeout The timeout
+     * @param unit The timeout time unit
+     * @return The total number of <i>Messages</i> retrieved in all
+     * MessageBatches added to the list
+     * @throws InterruptedException If the thread pool is shut down
+     */
     public int get(List<? super MessageBatch> into) throws InterruptedException {
         // If messages immediately available, return them without waiting
-        if (drain(into) > 0) {
-            return into.size();
-        }
+        drain(into);
         // wait for signal
         while (into.isEmpty()) {
-            // It *is* possible to have messages waiting which we will never
-            // be signalled for, so this needs to be a slow busywait.  That
-            // should only happen under heavy contention.
-            get(into, 250, TimeUnit.MILLISECONDS);
+            synchronized(this) {
+                wait();
+            }
+            drain(into);
         }
         return into.size();
     }
@@ -136,43 +209,41 @@ final class AsyncDeliveryQueue {
         }
         // Give a chance at message collection
         Thread.yield();
-        messagesForSubscriber.clear();
-        threadAffinity.clear();
+        arrays.clear();
+        threads.clear();
     }
 
     private int drain(List<? super MessageBatch> batch) {
         int result = 0;
         boolean resignal = false;
         Thread currentThread = Thread.currentThread();
-        for (Map.Entry<Long, Messages> e : messagesForSubscriber.entrySet()) {
-            // Ensure that only this thread can read messages for this key, until
-            // the batch for that key is closed.
-            Thread threadForKey = threadAffinity.putIfAbsent(e.getKey(), currentThread);
-            if (threadForKey != null && threadForKey != currentThread) {
-                // Some other thread is currently dispatching messages for
-                // this subscriber, so we won't take any
-                // But note it and signal another thread (would be nicer to have a
-                // per-long condition so we could signal the exact thread, but you can't have
-                // atomic operations across two maps without a lock)
-                resignal |= e.getValue().count > 0;
-                continue;
-            }
-            // Atomically swap in a new Messages, *if* the messages object returned by
-            // e.getValue() is still the one actually in the map - another thread may
-            // have been in this method concurrently and claimed it, in which case we
-            // skip this key - another thread already has its messages
-            boolean addToBatch;
-            synchronized (this) {
-                addToBatch = messagesForSubscriber.replace(e.getKey(), e.getValue(), new Messages());
-            }
-            if (addToBatch) {
-                long[] totalBytes = new long[1];
-                List<Message> msgs = e.getValue().drain(totalBytes);
+        int as = arrays.size();
+        final long[] totalBytes = new long[1];
+        for (int i = 0; i < as; i++) {
+            AtomicReferenceArray<Messages> arr = arrays.get(i);
+            for (int j = 0; j < arraySize; j++) {
+                long subscriberId = (long) (i * arraySize) + j;
+                boolean alreadyClaimed = !threads.get(i).compareAndSet(j, 0, currentThread.getId());
+                // Ensure that only this thread can read messages for this key, until
+                // the batch for that key is closed.
+                if (alreadyClaimed) {
+                    // Some other thread is currently dispatching messages for
+                    // this subscriber, so we won't take any
+                    // But note it and signal another thread (would be nicer to have a
+                    // per-long condition so we could signal the exact thread, but you can't have
+                    // atomic operations across two maps without a lock)
+                    Messages m = arr.get(j);
+                    resignal |= m != null && !m.isEmpty();
+                    continue;
+                }
+                Messages m = arr.get(j);
+                totalBytes[0] = 0L;
+                List<Message> msgs = m == null ? Collections.<Message>emptyList() : m.drain(totalBytes);
                 if (!msgs.isEmpty()) {
                     result += msgs.size();
-                    batch.add(new MessageBatchImpl(e.getKey(), msgs, currentThread, totalBytes[0]));
+                    batch.add(new MessageBatchImpl(subscriberId, msgs, currentThread, totalBytes[0]));
                 } else {
-                    threadAffinity.remove(e.getKey());
+                    threads.get(i).compareAndSet(j, currentThread.getId(), 0);
                 }
             }
         }
@@ -186,22 +257,52 @@ final class AsyncDeliveryQueue {
         return result;
     }
 
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < arrays.size(); i++) {
+            AtomicReferenceArray<Messages> arr = arrays.get(i);
+            for (int j = 0; j < arraySize; j++) {
+                Messages m = arr.get(i);
+                if (!m.isEmpty()) {
+                    int sid = (i * arraySize) + j;
+                    sb.append(sid).append(":").append(m);
+                }
+            }
+        }
+        return sb.toString();
+    }
+
     private void signalOneThread() {
         synchronized (this) {
-            notifyAll();
+            notify();
         }
     }
 
     int estimatedSize() {
         int result = 0;
-        for (Messages m : messagesForSubscriber.values()) {
-            result += m.count;
+        for (AtomicReferenceArray<Messages> a : arrays) {
+            for (int i = 0; i < arraySize; i++) {
+                Messages m = a.get(i);
+                if (m != null) {
+                    result += a.get(i).size();
+                }
+            }
         }
         return result;
     }
 
     Set<Long> lockedKeys() {
-        return threadAffinity.keySet();
+        Set<Long> result = new HashSet<>();
+        for (int i = 0; i < threads.size(); i++) {
+            AtomicLongArray a = threads.get(i);
+            for (int j = 0; j < arraySize; j++) {
+                long val = a.get(j);
+                if (val != 0L) {
+                    result.add((long) (i * arraySize) + j);
+                }
+            }
+        }
+        return result;
     }
 
     /**
@@ -279,8 +380,10 @@ final class AsyncDeliveryQueue {
             closed = true;
             // Ensure we don't remove a the wrong thread in the case close() is
             // not called from the same thread we have here
-            if (!wasClosed && threadAffinity.get(subscriberId) == creatingThread) {
-                threadAffinity.remove(subscriberId);
+            int index = (int) subscriberId / arraySize;
+            int offset = (int) subscriberId % arraySize;
+            if (!wasClosed) {
+                threads.get(index).compareAndSet(offset, creatingThread.getId(), 0);
             }
         }
 
@@ -303,40 +406,52 @@ final class AsyncDeliveryQueue {
 
         // A basic linked list structure, where the head is found by
         // iterating backwards
-        MessageEntry tail;
-        // Safe for atomic reads without a lock
-        private volatile int count;
+        AtomicReference<MessageEntry> tail;
+
+        Messages(Message message) {
+            tail = new AtomicReference<>(new MessageEntry(null, message));
+        }
+
+        Messages() {
+            tail = new AtomicReference<>();
+        }
 
         // Using plain synchronization here - a java.util.concurrent lock
         // doesn't buy us anything;  and we create these frequently and throw
         // them away, to have a new value if needed for atomic operations,
         // so the cheaper construction is, the better, and you already
         // get a synchronization monitor with every Java object
-        public Messages add(Message message) {
-            synchronized (this) {
-                count++;
-                // Replace the tail
-                if (tail == null) {
-                    tail = new MessageEntry(null, message);
+        public Messages add(final Message message) {
+            tail.getAndUpdate(new Applier(message));
+            return this;
+        }
+
+        // This is a JDK-8ism - if we're stuck on JDK 7,
+        // just synchronize in add and drain instead, but
+        // this gives us an atomic replacement of the tail
+        // without the overhead of a lock
+        static class Applier implements UnaryOperator<MessageEntry> {
+
+            private final Message message;
+
+            public Applier(Message message) {
+                this.message = message;
+            }
+
+            @Override
+            public MessageEntry apply(MessageEntry t) {
+                if (t == null) {
+                    return new MessageEntry(null, message);
                 } else {
-                    tail = new MessageEntry(tail, message);
+                    return new MessageEntry(t, message);
                 }
             }
-            return this;
         }
 
         public List<Message> drain(long[] totalBytes) {
             assert totalBytes != null && totalBytes.length == 1;
-//            if (count == 0) {
-//                return Collections.emptyList();
-//            }
             // Do the minimal amount under the lock
-            MessageEntry oldTail;
-            synchronized (this) {
-                oldTail = tail;
-                count = 0;
-                tail = null;
-            }
+            MessageEntry oldTail = tail.getAndSet(null);
             // Populate the list iterating backwards from the tail
             if (oldTail != null) {
                 if (oldTail.prev == null) {
@@ -352,6 +467,36 @@ final class AsyncDeliveryQueue {
             return Collections.emptyList();
         }
 
+        public boolean isEmpty() {
+            return tail.get() == null;
+        }
+
+        public int size() {
+            MessageEntry tail = this.tail.get();
+            int result = 0;
+            while (tail != null) {
+                result++;
+                tail = tail.prev;
+            }
+            return result;
+        }
+
+        public String toString() {
+            StringBuilder sb = new StringBuilder("Messages: ");
+            MessageEntry tail = this.tail.get();
+            while (tail != null) {
+                if (sb.length() > 0) {
+                    sb.append(", ");
+                }
+                sb.append(tail.message);
+                tail = tail.prev;
+            }
+            return sb.toString();
+        }
+
+        /**
+         * A single linked list entry in the queue
+         */
         static final class MessageEntry {
 
             private MessageEntry prev;
@@ -363,11 +508,14 @@ final class AsyncDeliveryQueue {
             }
 
             void drainTo(List<? super Message> messages, long[] totalBytes) {
+                // Iterate backwards populating the list of messages,
+                // and also collect the total byte count
                 MessageEntry e = this;
                 while (e != null) {
                     messages.add(0, e.message);
-                    if (e.message.getData() != null) {
-                        totalBytes[0] += e.message.getData().length;
+                    byte[] data = e.message.getData();
+                    if (data != null) {
+                        totalBytes[0] += data.length;
                     }
                     e = e.prev;
                 }

--- a/src/main/java/io/nats/client/ConnectionImpl.java
+++ b/src/main/java/io/nats/client/ConnectionImpl.java
@@ -1412,6 +1412,9 @@ class ConnectionImpl implements Connection {
         List<MessageBatch> batches = new LinkedList<>();
         for (;;) {
             asyncQueue.get(batches);
+            if (Thread.interrupted()) {
+                return;
+            }
             for (MessageBatch batch : batches) {
                 try {
                     AsyncSubscriptionImpl sub = (AsyncSubscriptionImpl) subs.get(batch.subscriberId());

--- a/src/main/java/io/nats/client/ConnectionImpl.java
+++ b/src/main/java/io/nats/client/ConnectionImpl.java
@@ -25,7 +25,6 @@ import static io.nats.client.Nats.ERR_SECURE_CONN_REQUIRED;
 import static io.nats.client.Nats.ERR_SECURE_CONN_WANTED;
 import static io.nats.client.Nats.ERR_SLOW_CONSUMER;
 import static io.nats.client.Nats.ERR_STALE_CONNECTION;
-import static io.nats.client.Nats.ERR_TCP_FLUSH_FAILED;
 import static io.nats.client.Nats.ERR_TIMEOUT;
 import static io.nats.client.Nats.PERMISSIONS_ERR;
 import static io.nats.client.Nats.TLS_SCHEME;
@@ -33,6 +32,7 @@ import static io.nats.client.Nats.TLS_SCHEME;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.annotations.SerializedName;
+import io.nats.client.AsyncDeliveryQueue.MessageBatch;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
@@ -49,6 +49,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -65,6 +66,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Lock;
@@ -219,6 +221,10 @@ class ConnectionImpl implements Connection {
     // The flusher signalling channel
     private BlockingQueue<Boolean> fch;
 
+    private final ExecutorService subscriptionDispatchPool;
+    private final AsyncDeliveryQueue asyncQueue;
+    private final int subscriptionConcurrency;
+
 //    ConnectionImpl() {
 //    }
 
@@ -233,6 +239,32 @@ class ConnectionImpl implements Connection {
             tcf = opts.getFactory();
         } else {
             tcf = new TcpConnectionFactory();
+        }
+        ExecutorService subscriptionPool = opts.subscriptionDispatchPool;
+        int concurrency = -1;
+        if (props.contains(Nats.PROP_SUBSCRIPTION_CONCURRENCY)) {
+            try {
+                concurrency = Integer.parseInt(props.getProperty(Nats.PROP_SUBSCRIPTION_CONCURRENCY));
+                if (concurrency > 0 && subscriptionPool == null) {
+                    subscriptionPool = Executors.newFixedThreadPool(concurrency);
+                }
+            } catch (NumberFormatException ex) {
+                throw new IllegalArgumentException("Value for subscription concurrency is not a number: "
+                    + props.getProperty(Nats.PROP_SUBSCRIPTION_CONCURRENCY));
+            }
+        } else {
+            subscriptionPool = opts.subscriptionDispatchPool;
+            if (subscriptionPool instanceof ThreadPoolExecutor) {
+                concurrency = ((ThreadPoolExecutor) subscriptionPool).getCorePoolSize();
+            } else {
+                concurrency = Runtime.getRuntime().availableProcessors();
+            }
+        }
+        subscriptionConcurrency = Math.max(concurrency, 1);
+        this.subscriptionDispatchPool = subscriptionPool;
+        asyncQueue = subscriptionPool == null ? null : new AsyncDeliveryQueue();
+        if (subscriptionPool != null) {
+            startDispatchPool();
         }
     }
 
@@ -1373,6 +1405,86 @@ class ConnectionImpl implements Connection {
         }
     }
 
+    void fetchAndDispatchAsyncMessages(int index) throws InterruptedException {
+        Thread.currentThread().setName("NATS async subscription thread " + index + " for " + opts.connectionName);
+        List<MessageBatch> batches = new LinkedList<>();
+        for (;;) {
+            asyncQueue.get(batches);
+            for (MessageBatch batch : batches) {
+                try {
+                    AsyncSubscriptionImpl sub = (AsyncSubscriptionImpl) subs.get(batch.subscriberId());
+                    if (sub != null) {
+                        MessageHandler handler = sub.getMessageHandler();
+                        List<Message> messages = batch.toList();
+                        boolean closed;
+                        long max;
+                        long delivered = 0L;
+                        long totalBytes = batch.totalBytes();
+                        sub.lock();
+                        try {
+                            max = sub.max;
+                            closed = sub.isClosed();
+                            if (!closed) {
+                                if (sub.delivered + messages.size() >= sub.max) {
+                                    messages = messages.subList(0, (int) (sub.max - sub.delivered));
+                                    totalBytes = 0;
+                                    for (Message msg : messages) {
+                                        if (msg.getData() != null) {
+                                            totalBytes += msg.getData().length;
+                                        }
+                                    }
+                                }
+                                delivered = sub.delivered += messages.size();
+                            }
+                            // The next two lines should probably be inside if (!closed)
+                            // but in the original code this is updated regardless, so
+                            // emulating that
+                            sub.pMsgs -= batch.size();
+                            sub.pBytes -= totalBytes;
+                        } finally {
+                            sub.unlock();
+                        }
+                        if (closed) {
+                            continue;
+                        }
+                        for (Message message : batch) {
+                            try {
+                                handler.onMessage(message);
+                            } catch (RuntimeException ex) {
+                                if (opts.asyncErrorCb != null) {
+                                    opts.asyncErrorCb.onException(new NATSException(ex, ConnectionImpl.this, sub));
+                                } else {
+                                    // This seems like a supremely bad idea, since it will abort message
+                                    // delivery, and eventually exit all the threads in the thread pool.
+                                    // Nonetheless, that is what the original code does.
+                                    throw ex;
+                                }
+                            }
+                        }
+                        if (max > 0 && delivered >= max) {
+                            mu.lock();
+                            try {
+                                removeSub(sub);
+                            } finally {
+                                mu.unlock();
+                            }
+                            break;
+                        }
+                    }
+                } finally {
+                    // This must be called to enable delivery of further messages
+                    // on threads other than this one - to ensure one batch of
+                    // messages doesn't get ahead of another one, AsyncDeliveryQueue
+                    // tracks the thread most recently given a batch of messages
+                    // and will not give further messages for the same subscriber 
+                    // to any other thread until close() is called on the
+                    // resulting batch
+                    batch.close();
+                }
+            }
+            batches.clear();
+        }
+    }
     /**
      * waitForMsgs waits on the conditional shared with readLoop and processMsg. It is used to
      * deliver messages to asynchronous subscribers.
@@ -1475,7 +1587,9 @@ class ConnectionImpl implements Connection {
                     handleSlowConsumer(sub, msg);
                 } else {
                     // We use mch for everything, unlike Go client
-                    if (sub.getChannel() != null) {
+                    if (sub instanceof AsyncSubscriptionImpl && !isThreadPerSubscriber()) {
+                        asyncQueue.add(parser.ps.ma.sid, msg);
+                    } else if (sub.getChannel() != null) {
                         if (sub.getChannel().add(msg)) {
                             sub.pCond.signal();
                             // Clear Slow Consumer status
@@ -1787,6 +1901,39 @@ class ConnectionImpl implements Connection {
         }
     }
 
+    boolean isThreadPerSubscriber() {
+        return subscriptionDispatchPool == null;
+    }
+
+    void startDispatchPool() {
+        for (int i = 0; i < subscriptionConcurrency; i++) {
+            this.subscriptionDispatchPool.submit(new AsyncMessageDispatch(i));
+        }
+    }
+
+    final class AsyncMessageDispatch implements Runnable {
+
+        private final int index;
+        AsyncMessageDispatch(int index) {
+            this.index = index;
+        }
+        public void run() {
+            try {
+                fetchAndDispatchAsyncMessages(index);
+            } catch (InterruptedException ex) {
+                // This is not actually a good idea, but is what the original
+                // code did.  In fact, setting the interrupted flag will do
+                // nothing, since all that happens from here is the thread
+                // exits and terminates.  But, for compatibility...
+                Thread.currentThread().interrupt();
+                // The point is, there is no way to guarantee that the *only*
+                // way this thread can become interrupted is because it
+                // *should* exit (which could break all asynchronous listening).
+                // It calls out to client code, so anything can happen.
+            }
+        }
+    }
+
     /**
      * subscribe is the internal subscribe function that indicates interest in a subject.
      *
@@ -1798,6 +1945,16 @@ class ConnectionImpl implements Connection {
      */
     SubscriptionImpl subscribe(String subject, String queue, MessageHandler cb,
                                BlockingQueue<Message> ch) {
+        if (!isThreadPerSubscriber() && cb != null && opts.asyncErrorCb == null
+                && !Boolean.getBoolean("unit.test")) {
+            throw new IllegalStateException("An async error callback must be set to "
+                    + "use async message delivery with a shared thread pool");
+        }
+        if (ch != null && cb != null) {
+            throw new IllegalArgumentException("Passed a queue for an asynchronous "
+                    + "subscription.  It will not be used and should be null if "
+                    + "a MessageHandler is passed.");
+        }
         final SubscriptionImpl sub;
         mu.lock();
         try {
@@ -1812,17 +1969,19 @@ class ConnectionImpl implements Connection {
 
             if (cb != null) {
                 sub = new AsyncSubscriptionImpl(this, subject, queue, cb);
-                // If we have an async callback, start up a sub specific Runnable to deliver the
-                // messages
-                subexec.submit(new Runnable() {
-                    public void run() {
-                        try {
-                            waitForMsgs((AsyncSubscriptionImpl) sub);
-                        } catch (InterruptedException e) {
-                            Thread.currentThread().interrupt();
+                if (isThreadPerSubscriber()) {
+                    // If we have an async callback, start up a sub specific Runnable to deliver the
+                    // messages
+                    subexec.submit(new Runnable() {
+                        public void run() {
+                            try {
+                                waitForMsgs((AsyncSubscriptionImpl) sub);
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                            }
                         }
-                    }
-                });
+                    });
+                }
             } else {
                 sub = new SyncSubscriptionImpl(this, subject, queue);
                 sub.setChannel(ch);

--- a/src/main/java/io/nats/client/Nats.java
+++ b/src/main/java/io/nats/client/Nats.java
@@ -206,6 +206,12 @@ public final class Nats {
      */
     public static final String PROP_USE_OLD_REQUEST_STYLE = "use.old.request.style";
 
+    /**
+     * The number of threads to use for async subscription dispatch.
+     * If not set or set to &lt;1, the original behavior of one thread per
+     * subscriber is used.
+     */
+    public static final String PROP_SUBSCRIPTION_CONCURRENCY = PFX + "subscription.concurrency";
     /*
      * Constants
      */

--- a/src/main/java/io/nats/client/Nats.java
+++ b/src/main/java/io/nats/client/Nats.java
@@ -445,7 +445,7 @@ public final class Nats {
      * @return the default {@link Options}
      */
     public static Options defaultOptions() {
-        return new Options.Builder().build();
+        return new Options.Builder().subscriptionConcurrency(4).build();
     }
 
     static List<URI> processUrlString(String url) {

--- a/src/main/java/io/nats/client/Options.java
+++ b/src/main/java/io/nats/client/Options.java
@@ -44,6 +44,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLContext;
 
@@ -89,6 +90,8 @@ public class Options {
     public ReconnectedCallback reconnectedCb;
     public ExceptionHandler asyncErrorCb;
 
+    ExecutorService subscriptionDispatchPool;
+
     // Size of the backing ByteArrayOutputStream buffer during reconnect.
     // Once this has been exhausted publish operations will error.
     final int reconnectBufSize;
@@ -131,7 +134,7 @@ public class Options {
         this.closedCb = builder.closedCb;
         this.reconnectedCb = builder.reconnectedCb;
         this.asyncErrorCb = builder.asyncErrorCb;
-
+        this.subscriptionDispatchPool = builder.subscriptionDispatchPool;
     }
 
     @Override
@@ -310,6 +313,10 @@ public class Options {
         return disconnectedCb;
     }
 
+    public ExecutorService getSubscriptionDispatchPool() {
+        return subscriptionDispatchPool;
+    }
+
     // public void addCertificate(X509Certificate cert) {
     // if (cert==null)
     // throw new IllegalArgumentException("Null certificate");
@@ -362,6 +369,7 @@ public class Options {
         ClosedCallback closedCb;
         ReconnectedCallback reconnectedCb;
         ExceptionHandler asyncErrorCb;
+        ExecutorService subscriptionDispatchPool;
 
         /**
          * Constructs a {@link Builder} instance based on the supplied {@link Options} instance.
@@ -641,6 +649,11 @@ public class Options {
             if (sslContext != null) {
                 this.secure = true;
             }
+            return this;
+        }
+
+        public Builder subscriptionDispatchPool(ExecutorService threadPool) {
+            this.subscriptionDispatchPool = threadPool;
             return this;
         }
 

--- a/src/main/java/io/nats/client/Options.java
+++ b/src/main/java/io/nats/client/Options.java
@@ -30,6 +30,7 @@ import static io.nats.client.Nats.PROP_RECONNECT_BUF_SIZE;
 import static io.nats.client.Nats.PROP_RECONNECT_WAIT;
 import static io.nats.client.Nats.PROP_SECURE;
 import static io.nats.client.Nats.PROP_SERVERS;
+import static io.nats.client.Nats.PROP_SUBSCRIPTION_CONCURRENCY;
 import static io.nats.client.Nats.PROP_TLS_DEBUG;
 import static io.nats.client.Nats.PROP_URL;
 import static io.nats.client.Nats.PROP_USERNAME;
@@ -102,6 +103,7 @@ public class Options {
 
     // TODO Allow users to set a custom "dialer" like Go. For now keep package-private
     final TcpConnectionFactory factory;
+    final int subscriptionConcurrency;
 
     // private List<X509Certificate> certificates =
     // new ArrayList<X509Certificate>();
@@ -135,6 +137,7 @@ public class Options {
         this.reconnectedCb = builder.reconnectedCb;
         this.asyncErrorCb = builder.asyncErrorCb;
         this.subscriptionDispatchPool = builder.subscriptionDispatchPool;
+        this.subscriptionConcurrency = builder.subscriptionConcurrency;
     }
 
     @Override
@@ -291,6 +294,10 @@ public class Options {
         return pingInterval;
     }
 
+    public int getSubscriptionConcurrency() {
+        return subscriptionConcurrency;
+    }
+
     public int getMaxPingsOut() {
         return maxPingsOut;
     }
@@ -365,6 +372,7 @@ public class Options {
         private SSLContext sslContext;
         private boolean tlsDebug;
         private TcpConnectionFactory factory;
+        private int subscriptionConcurrency = -1;
         DisconnectedCallback disconnectedCb;
         ClosedCallback closedCb;
         ReconnectedCallback reconnectedCb;
@@ -557,6 +565,10 @@ public class Options {
                 }
                 this.reconnectedCb = (ReconnectedCallback) instance;
             }
+            // PROP_SUBSCRIPTION_CONCURRENCY
+            if (props.containsKey(PROP_SUBSCRIPTION_CONCURRENCY)) {
+                this.subscriptionConcurrency = Integer.parseInt(props.getProperty(PROP_SUBSCRIPTION_CONCURRENCY, "-1"));
+            }
         }
 
         public Builder dontRandomize() {
@@ -654,6 +666,11 @@ public class Options {
 
         public Builder subscriptionDispatchPool(ExecutorService threadPool) {
             this.subscriptionDispatchPool = threadPool;
+            return this;
+        }
+
+        public Builder subscriptionConcurrency(int concurrency) {
+            this.subscriptionConcurrency = concurrency;
             return this;
         }
 

--- a/src/test/java/io/nats/client/AsyncDeliveryQueueTest.java
+++ b/src/test/java/io/nats/client/AsyncDeliveryQueueTest.java
@@ -54,15 +54,17 @@ import org.junit.Test;
 public class AsyncDeliveryQueueTest {
 
     private final AsyncDeliveryQueue q = new AsyncDeliveryQueue();
+    static final AtomicLong IDS = new AtomicLong();
+    static final AtomicLong MESSAGE_IDS = new AtomicLong();
 
-    private final SubscriberKey keyA = new SubscriberKey("a");
-    private final SubscriberKey keyB = new SubscriberKey("b");
-    private final SubscriberKey keyC = new SubscriberKey("c");
-    private final SubscriberKey keyD = new SubscriberKey("d");
-    private final SubscriberKey keyE = new SubscriberKey("e");
-    private final SubscriberKey keyF = new SubscriberKey("f");
-    private final SubscriberKey keyG = new SubscriberKey("g");
-    private final SubscriberKey[] keys = new SubscriberKey[]{keyA, keyB, keyC, keyD, keyE, keyF, keyG};
+    static final SubscriberKey keyA = new SubscriberKey("a");
+    static final SubscriberKey keyB = new SubscriberKey("b");
+    static final SubscriberKey keyC = new SubscriberKey("c");
+    static final SubscriberKey keyD = new SubscriberKey("d");
+    static final SubscriberKey keyE = new SubscriberKey("e");
+    static final SubscriberKey keyF = new SubscriberKey("f");
+    static final SubscriberKey keyG = new SubscriberKey("g");
+    static final SubscriberKey[] keys = new SubscriberKey[]{keyA, keyB, keyC, keyD, keyE, keyF, keyG};
 
     @Test
     public void testSimpleReadWrite() throws Throwable {
@@ -335,7 +337,7 @@ public class AsyncDeliveryQueueTest {
         }
     }
 
-    private static List<Message> messageBatch(SubscriberKey key, int size) {
+    static List<Message> messageBatch(SubscriberKey key, int size) {
         List<Message> result = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
             result.add(message(key, result));
@@ -343,14 +345,10 @@ public class AsyncDeliveryQueueTest {
         return result;
     }
 
-    private static final Message message(SubscriberKey key, List<? super Message> addTo) {
+    static final Message message(SubscriberKey key, List<? super Message> addTo) {
         Message message = new Message(key.name, null, bytes());
         return message;
     }
-
-    static final AtomicLong IDS = new AtomicLong();
-
-    static final AtomicLong MESSAGE_IDS = new AtomicLong();
 
     static List<ComparableMessageWrapper> toWrappers(List<? extends Message> msgs) {
         List<ComparableMessageWrapper> result = new ArrayList<>(msgs.size());
@@ -371,7 +369,7 @@ public class AsyncDeliveryQueueTest {
     // bytes and gives us a string representation that's helpful in error messages
     static class ComparableMessageWrapper implements Comparable<ComparableMessageWrapper> {
 
-        private final Message message;
+        final Message message;
 
         public ComparableMessageWrapper(Message message) {
             this.message = message;

--- a/src/test/java/io/nats/client/AsyncDeliveryQueueTest.java
+++ b/src/test/java/io/nats/client/AsyncDeliveryQueueTest.java
@@ -76,12 +76,12 @@ public class AsyncDeliveryQueueTest {
             q.add(4, m);
         }
         assertEquals(80, q.estimatedSize());
-        assertTrue(q.contains(1));
-        assertTrue(q.contains(2));
-        assertTrue(q.contains(3));
-        assertTrue(q.contains(4));
+        assertTrue(q.containsMessagesFor(1));
+        assertTrue(q.containsMessagesFor(2));
+        assertTrue(q.containsMessagesFor(3));
+        assertTrue(q.containsMessagesFor(4));
         q.remove(3);
-        assertFalse(q.contains(3));
+        assertFalse(q.containsMessagesFor(3));
         List<Message> removed = q.removeAndCollect(4);
         assertEquals(batch, removed);
 

--- a/src/test/java/io/nats/client/AsyncDeliveryQueueTest.java
+++ b/src/test/java/io/nats/client/AsyncDeliveryQueueTest.java
@@ -1,0 +1,497 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2017 Apcera, Inc..
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.nats.client;
+
+import io.nats.client.AsyncDeliveryQueue.MessageBatch;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Phaser;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.AbstractQueuedSynchronizer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+public class AsyncDeliveryQueueTest {
+
+    private final AsyncDeliveryQueue q = new AsyncDeliveryQueue();
+
+    private final SubscriberKey keyA = new SubscriberKey("a");
+    private final SubscriberKey keyB = new SubscriberKey("b");
+    private final SubscriberKey keyC = new SubscriberKey("c");
+    private final SubscriberKey keyD = new SubscriberKey("d");
+    private final SubscriberKey keyE = new SubscriberKey("e");
+    private final SubscriberKey keyF = new SubscriberKey("f");
+    private final SubscriberKey keyG = new SubscriberKey("g");
+    private final SubscriberKey[] keys = new SubscriberKey[]{keyA, keyB, keyC, keyD, keyE, keyF, keyG};
+
+    @Test
+    public void testSimpleReadWrite() throws Throwable {
+        List<Message> batch = messageBatch(keyA, 20);
+        for (Message m : batch) {
+            q.add(1, m);
+            q.add(2, m);
+            q.add(3, m);
+            q.add(4, m);
+        }
+        assertEquals(80, q.estimatedSize());
+        assertTrue(q.contains(1));
+        assertTrue(q.contains(2));
+        assertTrue(q.contains(3));
+        assertTrue(q.contains(4));
+        q.remove(3);
+        assertFalse(q.contains(3));
+        List<Message> removed = q.removeAndCollect(4);
+        assertEquals(batch, removed);
+
+        assertEquals(40, q.estimatedSize());
+        List<MessageBatch> batches = new ArrayList<>(2);
+        q.get(batches);
+        assertEquals(new HashSet<>(Arrays.asList(1L, 2L)), q.lockedKeys());
+        assertEquals(2, batches.size());
+        MessageBatch a = batches.get(0);
+        MessageBatch b = batches.get(1);
+        assertEquals(20, a.size());
+        assertEquals(20, b.size());
+        assertNotEquals(a.subscriberId(), b.subscriberId());
+        assertTrue(a.subscriberId() == 1 || a.subscriberId() == 2);
+        assertTrue(b.subscriberId() == 1 || b.subscriberId() == 2);
+        a.close();
+        b.close();
+        Iterator<Message> ai = a.iterator();
+        Iterator<Message> bi = b.iterator();
+        for (int i = 0; i < 20; i++) {
+            assertEquals(batch.get(i), ai.next());
+            assertEquals(batch.get(i), bi.next());
+        }
+        batches.clear();
+        q.get(batches, 10, TimeUnit.MILLISECONDS);
+        assertTrue(batches.isEmpty());
+        assertTrue(q.lockedKeys().isEmpty());
+    }
+
+    @Test
+    public void testDeliveryOrder() throws InterruptedException {
+        int threads = 16;
+        ExecutorService threadPool = Executors.newFixedThreadPool(threads * 2);
+        try {
+            Phaser phaser = new Phaser(1);
+            CountDownLatch submissionsDone = new CountDownLatch(1);
+            int total = 0;
+            List<Receiver> receivers = new LinkedList<>();
+            List<Message> batchSet = new ArrayList<>();
+            for (SubscriberKey key : keys) {
+                List<Message> batch = messageBatch(key, 1567);
+                batchSet.addAll(batch);
+                total += batch.size();
+            }
+            threadPool.submit(new Deliverer(batchSet, 17, submissionsDone, phaser));
+            MultiCountDownLatch receiversDone = new MultiCountDownLatch(total);
+            for (int i = 0; i < threads; i++) {
+                Receiver receiver = new Receiver(phaser, receiversDone);
+                receivers.add(receiver);
+                threadPool.submit(receiver);
+            }
+            // Release all the threads, so they are all launched at the same time
+            phaser.arriveAndDeregister();
+            // Wait for all the messages to be submitted to the queue
+            submissionsDone.await(60, TimeUnit.SECONDS);
+            // Wait until we've been notified that the received message count
+            // matches the total number of messages
+            receiversDone.await(60, TimeUnit.SECONDS);
+
+            // Make sure the total received message count across all receivers
+            // matches the total we expect
+            int receivedTotal = 0;
+            for (Receiver r : receivers) {
+                receivedTotal += r.total();
+            }
+            // Ensure that each batch of messages only contained messages for one
+            // subscriber, and that no messages arrived out of order
+            for (Receiver r : receivers) {
+                r.assertEachBatchIsForOneSubscriber();
+                r.assertBatchesArrivedInOrder();
+                r.shutdown = true;
+            }
+
+            // Now check total order - combine all the receivers maps of
+            // batch to iteration into one, and do the same test
+            Receiver r1 = new Receiver(receivers);
+            r1.assertBatchesArrivedInOrder();
+
+            // Check that the total really matches
+            assertEquals(total, receivedTotal);
+        } finally {
+            threadPool.shutdownNow();
+        }
+    }
+
+    long findQueueKeyFor(Message msg) {
+        for (SubscriberKey k : keys) {
+            if (k.name.equals(msg.getSubject())) {
+                return k.id;
+            }
+        }
+        throw new AssertionError("Unknown subject " + msg.getSubject());
+    }
+
+    class Deliverer implements Runnable {
+
+        private final List<Message> toDeliver;
+        private final int sleepEvery;
+        private final CountDownLatch onDone;
+        private final Phaser phaser;
+
+        public Deliverer(List<Message> toDeliver, int sleepEvery, CountDownLatch onDone, Phaser phaser) {
+            this.toDeliver = toDeliver;
+            this.sleepEvery = sleepEvery;
+            this.onDone = onDone;
+            this.phaser = phaser;
+        }
+
+        @Override
+        public void run() {
+            // Wait for all the receivers to get to the party
+            phaser.arriveAndAwaitAdvance();
+            try {
+                for (int i = 0; i < toDeliver.size(); i++) {
+                    // Stagger batches with a sleep, so we don't blast them all into
+                    // the queue and have them grabbed by one consumer
+                    // All sleeps and batch size counts should be prime numbers to
+                    // avoid cases where things look like they work if they are
+                    // multiples of each other.
+                    if (sleepEvery > 0 && (i % sleepEvery) == 0) {
+                        try {
+                            Thread.sleep(23);
+                        } catch (InterruptedException ex) {
+                            Logger.getLogger(AsyncDeliveryQueueTest.class.getName()).log(Level.SEVERE, null, ex);
+                        }
+                    }
+                    Message msg = toDeliver.get(i);
+                    long key = findQueueKeyFor(msg);
+                    q.add(key, msg);
+                    Thread.yield();
+                }
+            } catch (Exception ex) {
+                ex.printStackTrace();
+            } finally {
+                onDone.countDown();
+            }
+        }
+    }
+
+    // Provides a "timestamp" for each batch received, so we can test the
+    // order later
+    final AtomicInteger BATCHES = new AtomicInteger();
+
+    class Receiver implements Runnable {
+
+        final Map<Integer, List<MessageBatch>> batches = new HashMap<>();
+        private final Phaser phaser;
+        private final MultiCountDownLatch latch;
+        volatile boolean shutdown;
+
+        public Receiver(List<Receiver> others) {
+            this(null, null);
+            for (Receiver r : others) {
+                batches.putAll(r.batches);
+            }
+        }
+
+        public Receiver(Phaser phaser, MultiCountDownLatch latch) {
+            this.phaser = phaser;
+            this.latch = latch;
+        }
+
+        int total() {
+            int result = 0;
+            for (Map.Entry<Integer, List<MessageBatch>> e : batches.entrySet()) {
+                for (MessageBatch mb : e.getValue()) {
+                    result += mb.size();
+                }
+            }
+            return result;
+        }
+
+        void assertBatchesArrivedInOrder() {
+            Map<Long, List<Message>> msgs = new HashMap<>();
+            List<Integer> iterations = new ArrayList<>(batches.keySet());
+            Collections.sort(iterations);
+            for (Integer key : iterations) {
+                for (MessageBatch batch : batches.get(key)) {
+                    List<Message> m = msgs.get(batch.subscriberId());
+                    if (m == null) {
+                        m = new ArrayList<>();
+                        msgs.put(batch.subscriberId(), m);
+                    }
+                    for (Message msg : batch) {
+                        m.add(msg);
+                    }
+                }
+            }
+            for (Map.Entry<Long, List<Message>> e : msgs.entrySet()) {
+                assertListSorted("Out of order messages for " + e.getKey() + " in " + toWrappers(e.getValue()), e.getValue());
+            }
+        }
+
+        void assertEachBatchIsForOneSubscriber() {
+            for (Map.Entry<Integer, List<MessageBatch>> e : batches.entrySet()) {
+                for (MessageBatch b : e.getValue()) {
+                    Set<String> seenSubjects = new HashSet<>();
+                    for (Message ms : b) {
+                        seenSubjects.add(ms.getSubject());
+                    }
+                    assertTrue("Saw more than one subject: " + seenSubjects
+                            + " in batch " + e.getKey() + ": " + b, seenSubjects.size() <= 1);
+                }
+            }
+        }
+
+        @Override
+        public void run() {
+            phaser.arriveAndAwaitAdvance();
+            for (int ix = 0;; ix++) {
+                List<MessageBatch> l = new ArrayList<>();
+                try {
+                    // Fetch from the queue
+                    q.get(l);
+                    int batch = BATCHES.getAndIncrement();
+                    int total = 0;
+                    for (MessageBatch b : l) {
+                        total += b.size();
+                        b.close();
+                    }
+                    if (total > 0) {
+                        batches.put(batch, l);
+                        latch.countDown(total);
+                    }
+                    if (ix % 37 == 0) {
+                        Thread.sleep(200);
+                    }
+                    // Allow other receiver threads to get ahead
+                    // May do nothing on some OS's
+                    Thread.yield();
+                } catch (Exception ex) {
+                    if (shutdown) {
+                        return;
+                    }
+                    Logger.getLogger(AsyncDeliveryQueueTest.class.getName()).log(Level.SEVERE, null, ex);
+                    break;
+                }
+            }
+        }
+
+        public String toString() {
+            // For verbose logging
+            StringBuilder sb = new StringBuilder("RECEIVER\n");
+            for (Map.Entry<Integer, List<MessageBatch>> e : batches.entrySet()) {
+                sb.append("  Iter ").append(e.getKey()).append(" with ").append(e.getValue().size()).append(" batches\n");
+                for (MessageBatch b : e.getValue()) {
+                    for (Message msg : b) {
+                        sb.append("    ").append(new ComparableMessageWrapper(msg).toString()).append("\n");
+                    }
+                }
+            }
+            return sb.toString();
+        }
+    }
+
+    private static List<Message> messageBatch(SubscriberKey key, int size) {
+        List<Message> result = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            result.add(message(key, result));
+        }
+        return result;
+    }
+
+    private static final Message message(SubscriberKey key, List<? super Message> addTo) {
+        Message message = new Message(key.name, null, bytes());
+        return message;
+    }
+
+    static final AtomicLong IDS = new AtomicLong();
+
+    static final AtomicLong MESSAGE_IDS = new AtomicLong();
+
+    static List<ComparableMessageWrapper> toWrappers(List<? extends Message> msgs) {
+        List<ComparableMessageWrapper> result = new ArrayList<>(msgs.size());
+        for (Message msg : msgs) {
+            result.add(new ComparableMessageWrapper(msg));
+        }
+        return result;
+    }
+
+    static void assertListSorted(String msg, List<Message> messages) {
+        List<ComparableMessageWrapper> wrappers = toWrappers(messages);
+        List<ComparableMessageWrapper> sorted = new ArrayList<>(wrappers);
+        Collections.sort(sorted);
+        assertEquals(msg, sorted, wrappers);
+    }
+
+    // A wrapper for Message that lets us extract a sequence number from its
+    // bytes and gives us a string representation that's helpful in error messages
+    static class ComparableMessageWrapper implements Comparable<ComparableMessageWrapper> {
+
+        private final Message message;
+
+        public ComparableMessageWrapper(Message message) {
+            this.message = message;
+        }
+
+        long messageId() {
+            return idForMessage(message);
+        }
+
+        public String toString() {
+            return messageId() + ":" + message.getSubject();
+        }
+
+        public boolean equals(Object o) {
+            if (o == this) {
+                return true;
+            } else if (o == null) {
+                return false;
+            } else if (o instanceof ComparableMessageWrapper) {
+                ComparableMessageWrapper c = (ComparableMessageWrapper) o;
+                if (c.messageId() == messageId()) {
+                    return c.message.getSubject().equals(c.message.getSubject());
+                }
+            }
+            return false;
+        }
+
+        public int hashCode() {
+            Long id = messageId();
+            return id.hashCode();
+        }
+
+        @Override
+        public int compareTo(ComparableMessageWrapper o) {
+            Long a = messageId();
+            Long b = o.messageId();
+            return a.compareTo(b);
+        }
+    }
+
+    static long idForMessage(Message message) {
+        return ByteBuffer.wrap(message.getData()).asLongBuffer().get();
+    }
+
+    static final byte[] bytes() {
+        byte[] result = new byte[8];
+        ByteBuffer.wrap(result).asLongBuffer().put(MESSAGE_IDS.incrementAndGet());
+        return result;
+    }
+
+    static final class SubscriberKey {
+
+        final long id = IDS.incrementAndGet();
+        final String name;
+
+        public SubscriberKey(String name) {
+            this.name = name;
+        }
+    }
+
+    // Like a CountDownLatch but can count down N items at once, used
+    // to track when all messages are received
+    static class MultiCountDownLatch {
+
+        private static final class Sync extends AbstractQueuedSynchronizer {
+
+            Sync(int count) {
+                setState(count);
+            }
+
+            int getCount() {
+                return getState();
+            }
+
+            void reset(int count) {
+                setState(count);
+            }
+
+            @Override
+            protected int tryAcquireShared(int acquires) {
+                return (getState() == 0) ? 1 : -1;
+            }
+
+            @Override
+            protected boolean tryReleaseShared(int releases) {
+                // Decrement count; signal when transition to zero
+                for (;;) {
+                    int c = getState();
+                    if (c == 0) {
+                        return false;
+                    }
+                    int nextc = c - releases;
+                    if (compareAndSetState(c, nextc)) {
+                        return nextc == 0;
+                    }
+                }
+            }
+        }
+
+        private final Sync sync;
+
+        public MultiCountDownLatch(int count) {
+            this.sync = new Sync(count);
+        }
+
+        public void await() throws InterruptedException {
+            sync.acquireSharedInterruptibly(1);
+        }
+
+        public boolean await(long timeout, TimeUnit unit)
+                throws InterruptedException {
+            return sync.tryAcquireSharedNanos(1, unit.toNanos(timeout));
+        }
+
+        public void countDown(int qty) {
+            sync.releaseShared(qty);
+        }
+
+        public long getCount() {
+            return sync.getCount();
+        }
+    }
+}

--- a/src/test/java/io/nats/client/ConnectionImplTest.java
+++ b/src/test/java/io/nats/client/ConnectionImplTest.java
@@ -67,7 +67,6 @@ import java.util.Properties;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -187,7 +186,7 @@ public class ConnectionImplTest {
 //    }
 
     static Options defaultOptions() {
-        return new Options.Builder().subscriptionDispatchPool(Executors.newFixedThreadPool(4)).build();
+        return new Options.Builder().subscriptionConcurrency(4).build();
     }
 
     @Test

--- a/src/test/java/io/nats/client/ConnectionImplTest.java
+++ b/src/test/java/io/nats/client/ConnectionImplTest.java
@@ -23,7 +23,6 @@ import static io.nats.client.Nats.ERR_SECURE_CONN_REQUIRED;
 import static io.nats.client.Nats.ERR_SECURE_CONN_WANTED;
 import static io.nats.client.Nats.ERR_STALE_CONNECTION;
 import static io.nats.client.Nats.ERR_TIMEOUT;
-import static io.nats.client.Nats.defaultOptions;
 import static io.nats.client.UnitTestUtilities.await;
 import static io.nats.client.UnitTestUtilities.defaultInfo;
 import static io.nats.client.UnitTestUtilities.newMockedConnection;
@@ -40,7 +39,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -69,6 +67,7 @@ import java.util.Properties;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -186,6 +185,10 @@ public class ConnectionImplTest {
 //    public void testMocking() {
 //        assertEquals(tcf, connection.getTcpConnectionFactory());
 //    }
+
+    static Options defaultOptions() {
+        return new Options.Builder().subscriptionDispatchPool(Executors.newFixedThreadPool(4)).build();
+    }
 
     @Test
     public void testConnectProto() throws Exception {
@@ -1498,12 +1501,6 @@ public class ConnectionImplTest {
             assertEquals(1, c.getStats().getInMsgs());
             // InBytes should be incremented by length
             assertEquals(length, c.getStats().getInBytes());
-            // sub.addMessage(msg) should have been called exactly once
-            verify(mchMock, times(1)).add(any(Message.class));
-            // condition should have been signaled
-            verify(sub.pCond, times(1)).signal();
-            // sub.setSlowConsumer(false) should have been called
-            verify(sub, times(1)).setSlowConsumer(eq(false));
             // c.removeSub should NOT have been called
             verify(c, times(0)).removeSub(eq(sub));
         }
@@ -1573,10 +1570,6 @@ public class ConnectionImplTest {
             assertEquals(1, c.getStats().getInMsgs());
             // InBytes should be incremented by length, even if the sub stats don't increase
             assertEquals(length, c.getStats().getInBytes());
-            // handleSlowConsumer should have been called zero times
-            verify(c, times(1)).handleSlowConsumer(eq(sub), any(Message.class));
-            // sub.addMessage(msg) should have been called
-            verify(mchMock, times(1)).add(any(Message.class));
             // the condition should not have been signaled
             verify(sub.pCond, times(0)).signal();
         }

--- a/src/test/java/io/nats/client/TestExceptionHandler.java
+++ b/src/test/java/io/nats/client/TestExceptionHandler.java
@@ -1,0 +1,65 @@
+package io.nats.client;
+
+/*
+ * The MIT License
+ *
+ * Copyright 2017 Apcera, Inc..
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+/**
+ *
+ * @author Tim Boudreau
+ */
+public class TestExceptionHandler implements ExceptionHandler {
+
+    Throwable thrown = null;
+
+    synchronized void rethrow() throws Throwable {
+        if (thrown != null) {
+            throw thrown;
+        }
+    }
+
+    volatile Thread testThread;
+
+    void pickUpTestThread() {
+        testThread = Thread.currentThread();
+    }
+
+    @Override
+    public synchronized void onException(NATSException ex) {
+        ex.printStackTrace(System.out);
+        Throwable t = ex;
+        while (t.getCause() != null) {
+            t = t.getCause();
+            if (t.getCause() == null) {
+                break;
+            }
+        }
+        if (thrown != null) {
+            thrown.addSuppressed(t);
+        } else {
+            thrown = t;
+        }
+        if (testThread != null) {
+            testThread.interrupt();
+        }
+    }
+}

--- a/src/test/java/io/nats/client/UnitTestUtilities.java
+++ b/src/test/java/io/nats/client/UnitTestUtilities.java
@@ -27,7 +27,6 @@ import java.net.URL;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -63,14 +62,18 @@ class UnitTestUtilities {
         return connect(Nats.DEFAULT_URL);
     }
 
+    static synchronized Connection newDefaultConnection(ExceptionHandler onError) throws IOException {
+        return connect(Nats.DEFAULT_URL, new Options.Builder().errorCb(onError).build());
+    }
+
     static synchronized Connection newDefaultConnection(TcpConnectionFactory tcf)
             throws IOException {
-        return new Options.Builder().subscriptionDispatchPool(Executors.newFixedThreadPool(4)).factory(tcf).build().connect();
+        return new Options.Builder().subscriptionConcurrency(4).factory(tcf).build().connect();
     }
 
     static synchronized Connection newDefaultConnection(TcpConnectionFactory tcf, Options opts)
             throws IOException {
-        return new Options.Builder(opts).subscriptionDispatchPool(Executors.newFixedThreadPool(4)).factory(tcf).build().connect();
+        return new Options.Builder(opts).subscriptionConcurrency(4).factory(tcf).build().connect();
     }
 
     static TcpConnection newMockedTcpConnection() throws IOException {
@@ -197,7 +200,7 @@ class UnitTestUtilities {
     }
 
     static Connection newMockedConnection(String url) throws IOException {
-        Options opts = new Options.Builder().subscriptionDispatchPool(Executors.newFixedThreadPool(4)).build();
+        Options opts = new Options.Builder().subscriptionConcurrency(4).build();
         opts.url = url;
         return newMockedConnection(opts);
     }
@@ -212,13 +215,13 @@ class UnitTestUtilities {
         if (opts == null) {
             options = new Options.Builder(Nats.defaultOptions())
                     .factory(tcfMock)
-                    .subscriptionDispatchPool(Executors.newFixedThreadPool(4))
+                    .subscriptionConcurrency(4)
                     .build();
             options.url = Nats.DEFAULT_URL;
         } else if (opts.getFactory() == null) {
-            options = new Options.Builder(opts).subscriptionDispatchPool(Executors.newFixedThreadPool(4)).factory(tcfMock).build();
+            options = new Options.Builder(opts).subscriptionConcurrency(4).factory(tcfMock).build();
         } else {
-            options = new Options.Builder(opts).subscriptionDispatchPool(Executors.newFixedThreadPool(4)).build();
+            options = new Options.Builder(opts).subscriptionConcurrency(4).build();
         }
         return Nats.connect(options.url, options);
     }
@@ -373,7 +376,7 @@ class UnitTestUtilities {
     }
 
     static boolean await(CountDownLatch latch) {
-        return await(latch, 5, TimeUnit.SECONDS);
+        return await(latch, 15, TimeUnit.SECONDS);
     }
 
     static boolean await(CountDownLatch latch, long timeout, TimeUnit unit) {

--- a/src/test/java/io/nats/client/UnitTestUtilities.java
+++ b/src/test/java/io/nats/client/UnitTestUtilities.java
@@ -27,6 +27,7 @@ import java.net.URL;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -64,12 +65,12 @@ class UnitTestUtilities {
 
     static synchronized Connection newDefaultConnection(TcpConnectionFactory tcf)
             throws IOException {
-        return new Options.Builder().factory(tcf).build().connect();
+        return new Options.Builder().subscriptionDispatchPool(Executors.newFixedThreadPool(4)).factory(tcf).build().connect();
     }
 
     static synchronized Connection newDefaultConnection(TcpConnectionFactory tcf, Options opts)
             throws IOException {
-        return new Options.Builder(opts).factory(tcf).build().connect();
+        return new Options.Builder(opts).subscriptionDispatchPool(Executors.newFixedThreadPool(4)).factory(tcf).build().connect();
     }
 
     static TcpConnection newMockedTcpConnection() throws IOException {
@@ -196,7 +197,7 @@ class UnitTestUtilities {
     }
 
     static Connection newMockedConnection(String url) throws IOException {
-        Options opts = Nats.defaultOptions();
+        Options opts = new Options.Builder().subscriptionDispatchPool(Executors.newFixedThreadPool(4)).build();
         opts.url = url;
         return newMockedConnection(opts);
     }
@@ -211,12 +212,13 @@ class UnitTestUtilities {
         if (opts == null) {
             options = new Options.Builder(Nats.defaultOptions())
                     .factory(tcfMock)
+                    .subscriptionDispatchPool(Executors.newFixedThreadPool(4))
                     .build();
             options.url = Nats.DEFAULT_URL;
         } else if (opts.getFactory() == null) {
-            options = new Options.Builder(opts).factory(tcfMock).build();
+            options = new Options.Builder(opts).subscriptionDispatchPool(Executors.newFixedThreadPool(4)).factory(tcfMock).build();
         } else {
-            options = new Options.Builder(opts).build();
+            options = new Options.Builder(opts).subscriptionDispatchPool(Executors.newFixedThreadPool(4)).build();
         }
         return Nats.connect(options.url, options);
     }


### PR DESCRIPTION
The following is a new patch to address nats-io/jnats#113 which makes the same API changes as the preceding one (ability to pass an `ExecutorService` or set subscription.concurrency property or both), with the following changes:

 * The subscription.concurrency property is used to determine how many runnables are dispatched to the thread pool to handle subscription messages.  If the property is not set, then:
   * If the passed `ExecutorService` is an instanceof `ThreadPoolExecutor` then `getCorePoolSize()` is used
   * If not, `Runtime.getRuntime().availableProcessors()` is used
 * Introduces `AsyncDispatchQueue`, which uses atomic operations on `ConcurrentHashMap` to manage the mapping of subscription ids to individual queues, and individual queues which use a straightforward linked-list structure - uses as minimal locking as I could devise and have the result be correct
   * Note this means the queue held by `SubscriptionImpl` is not used *at all* - having the cache/queue know only about longs and messages is a cleaner and much more leak-proof approach than having it fiddle with subscription implementation classes
   * See the fairly exhaustive unit tests

I believe this meets all the requirements listed in the bug;  I've attempted to comment the code fairly thoroughly since it visits a few infrequently visited corners of java.util.concurrent.

Tests pass - I've set up `ConnectionImplTest` to enable the feature by default (long term, it might be a good idea to run async subscription tests twice, once with and once without this behavior).

#### Notes

Removed a few lines from tests where the thing tested is not relevant - in particular, tests for calls to `setSlowConsumer()` for asynchronous subscriptions:  In fact, at runtime that would never have been called before or now, because it is only triggered if the `ch` argument to `ConnectionImpl.subscribe()`, a `LinkedBlockingQueue` with a limit was passed in (the default is unbounded), and the original code only sets the channel in the case of a synchronous consumer, so the passed-in queue was ignored for async subscriptions already.  So nothing is being lost that ever did anything - it should probably have always been an error to pass in a queue if you are passing in a `MessageHandler`, since the queue was and is ignored in that case.  For that matter, `AsyncSubscription` should probably not have a queue - a bigger but doable project would be to factor out an abstract superclass for `SubscriptionImpl` and AsyncSubscriptionImpl, so there aren't impedance mismatches.

Dealing with exceptions thrown by `MessageHandler`s:  The original code simply aborts the subscriber thread - no further messages will be delivered.  With a shared thread pool, this would impact all subscriptions.  What I did is pass it to the async error callback if one is present, and throw an exception in `subscribe()` if you don't have one and pooled subscription handling is on.

One other note on that:  The original code handles `InterruptedException` (which might be a hint that the thread pool is shutting down) by setting the thread's interrupted flag and exiting.  Setting the interrupted flag on a thread that is about to terminate does nothing;  and this is a thread that invokes client code - the InterruptedException could be thrown from there, in which case exiting isn't actually the right thing.  I kept compatibility with that, but a saner thing to do would be to test the thread pool's `isShutdown()` and decide to exit or not based on that.

### Testing

So, after pulling another all-nighter on this, I run it and the tests pass.  Yay!  That seems a little too good to be true, ao I instrument a few bits of code to see just how extensively the new code is being touched:  Almost not at all.  Two times in the entire suite - after altering `UnitTestUtilities` to *always* use a thread pool for delivery, and finding any other cases that involve a `MessageHandler` and altering them.

So does it work?  I don't know - it seems like there's a lot of mocks creating the illusion of test coverage here while testing far less than it appears.  What tests there are pass, but those that actually touch asynchronous subscriptions are trivial.
