### PR TITLE
[ADDED] Global Message Delivery Thread Pool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,6 @@ deploy:
     repo: nats-io/java-nats
     tags: true
     jdk: oraclejdk8
-notifications:
-  email:
-  - larry@apcera.com
 env:
   global:
   - GPG_DIR=${TRAVIS_BUILD_DIR}/.travis/keyrings

--- a/src/it/java/io/nats/client/ITAuthTest.java
+++ b/src/it/java/io/nats/client/ITAuthTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2015-2016 Apcera Inc. All rights reserved. This program and the accompanying
+ *  Copyright (c) 2015-2017 Apcera Inc. All rights reserved. This program and the accompanying
  *  materials are made available under the terms of the MIT License (MIT) which accompanies this
  *  distribution, and is available at http://opensource.org/licenses/MIT
  */
@@ -17,11 +17,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -30,28 +25,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 @Category(IntegrationTest.class)
-public class ITAuthTest {
-    @Rule
-    public TestCasePrinterRule pr = new TestCasePrinterRule(System.out);
-
+public class ITAuthTest extends ITBaseTest {
     private int hitDisconnect;
-
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-    }
-
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-    }
-
-    @Before
-    public void setUp() throws Exception {
-
-    }
-
-    @After
-    public void tearDown() throws Exception {
-    }
 
     @Test
     public void testAuth() {

--- a/src/it/java/io/nats/client/ITBaseTest.java
+++ b/src/it/java/io/nats/client/ITBaseTest.java
@@ -26,13 +26,6 @@ public class ITBaseTest {
         if (prop != null) {
             msgDeliveryPoolSize = Integer.parseInt(prop);
         }
-        if (msgDeliveryPoolSize == 0) {
-            // If the system environment variable JNATS_MSG_DELIVERY_THREAD_POOL_SIZE
-            // exists (and number if positive), the library will create the thread
-            // pool. We need to shutdown the pool here. Individual tests may create
-            // the pool with the size they want.
-            Nats.shutdownMsgDeliveryThreadPool();
-        }
     }
 
     @AfterClass
@@ -46,7 +39,7 @@ public class ITBaseTest {
         // a resource in the message callback preventing the pool to
         // be shutdown.
         if (msgDeliveryPoolSize > 0) {
-            Nats.setMsgDeliveryThreadPoolSize(msgDeliveryPoolSize);
+            Nats.createMsgDeliveryThreadPool(msgDeliveryPoolSize);
         }
     }
 

--- a/src/it/java/io/nats/client/ITBaseTest.java
+++ b/src/it/java/io/nats/client/ITBaseTest.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2017 Apcera Inc. All rights reserved. This program and the accompanying
+ *  materials are made available under the terms of the MIT License (MIT) which accompanies this
+ *  distribution, and is available at http://opensource.org/licenses/MIT
+ */
+
+package io.nats.client;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.experimental.categories.Category;
+
+@Category(IntegrationTest.class)
+public class ITBaseTest {
+    static int msgDeliveryPoolSize = 0;
+
+    @Rule
+    public TestCasePrinterRule pr = new TestCasePrinterRule(System.out);
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        String prop = System.getProperty("msgDeliveryPoolSize");
+        if (prop != null) {
+            msgDeliveryPoolSize = Integer.parseInt(prop);
+        }
+        if (msgDeliveryPoolSize == 0) {
+            // If the system environment variable JNATS_MSG_DELIVERY_THREAD_POOL_SIZE
+            // exists (and number if positive), the library will create the thread
+            // pool. We need to shutdown the pool here. Individual tests may create
+            // the pool with the size they want.
+            Nats.shutdownMsgDeliveryThreadPool();
+        }
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        // If need be, setup the message delivery thread pool for each
+        // test. This allows finding out if a test is holding onto
+        // a resource in the message callback preventing the pool to
+        // be shutdown.
+        if (msgDeliveryPoolSize > 0) {
+            Nats.setMsgDeliveryThreadPoolSize(msgDeliveryPoolSize);
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        // Shutdown the message delivery pool if one was set.
+        Nats.shutdownMsgDeliveryThreadPool();
+    }
+}

--- a/src/it/java/io/nats/client/ITBasicTest.java
+++ b/src/it/java/io/nats/client/ITBasicTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2015-2016 Apcera Inc. All rights reserved. This program and the accompanying
+ *  Copyright (c) 2015-2017 Apcera Inc. All rights reserved. This program and the accompanying
  *  materials are made available under the terms of the MIT License (MIT) which accompanies this
  *  distribution, and is available at http://opensource.org/licenses/MIT
  */
@@ -25,10 +25,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -49,35 +46,17 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 @Category(IntegrationTest.class)
-public class ITBasicTest {
-
+public class ITBasicTest extends ITBaseTest {
     @Rule
     public final ExpectedException thrown = ExpectedException.none();
-
-    @Rule
-    public TestCasePrinterRule pr = new TestCasePrinterRule(System.out);
 
     private final ExecutorService executor = Executors.newCachedThreadPool();
     UnitTestUtilities utils = new UnitTestUtilities();
 
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-    }
-
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-    }
-
     @Before
     public void setUp() throws Exception {
+        super.setUp();
         MockitoAnnotations.initMocks(this);
-    }
-
-    /**
-     * @throws java.lang.Exception if a problem occurs
-     */
-    @After
-    public void tearDown() throws Exception {
     }
 
     @Test
@@ -285,17 +264,17 @@ public class ITBasicTest {
                 c.publish("foo", omsg);
                 c.flush();
 
-                int r1 = s1.getQueuedMessageCount();
-                int r2 = s2.getQueuedMessageCount();
+                int r1 = s1.getPendingMsgs();
+                int r2 = s2.getPendingMsgs();
                 assertEquals("Received too many messages for multiple queue subscribers", 1,
                         r1 + r2);
 
                 // Drain the messages.
                 s1.nextMessage(250, TimeUnit.MILLISECONDS);
-                assertEquals(0, s1.getQueuedMessageCount());
+                assertEquals(0, s1.getPendingMsgs());
 
                 s2.nextMessage(250, TimeUnit.MILLISECONDS);
-                assertEquals(0, s2.getQueuedMessageCount());
+                assertEquals(0, s2.getPendingMsgs());
 
                 int total = 1000;
                 for (int i = 0; i < total; i++) {
@@ -308,8 +287,8 @@ public class ITBasicTest {
                 assertEquals(total, si1.getChannel().size() + si2.getChannel().size());
 
                 final int variance = (int) (total * 0.15);
-                r1 = s1.getQueuedMessageCount();
-                r2 = s2.getQueuedMessageCount();
+                r1 = s1.getPendingMsgs();
+                r2 = s2.getPendingMsgs();
                 assertEquals("Incorrect total number of messages: ", total, r1 + r2);
 
                 double expected = total / 2;

--- a/src/it/java/io/nats/client/ITClusterTest.java
+++ b/src/it/java/io/nats/client/ITClusterTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2015-2016 Apcera Inc. All rights reserved. This program and the accompanying
+ *  Copyright (c) 2015-2017 Apcera Inc. All rights reserved. This program and the accompanying
  *  materials are made available under the terms of the MIT License (MIT) which accompanies this
  *  distribution, and is available at http://opensource.org/licenses/MIT
  */
@@ -20,11 +20,6 @@ import static org.junit.Assert.fail;
 
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.StringUtils;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -43,27 +38,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 @Category(IntegrationTest.class)
-public class ITClusterTest {
-
-    @Rule
-    public TestCasePrinterRule pr = new TestCasePrinterRule(System.out);
-
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-    }
-
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-    }
-
-    @Before
-    public void setUp() throws Exception {
-    }
-
-    @After
-    public void tearDown() throws Exception {
-    }
-
+public class ITClusterTest extends ITBaseTest {
     private static final String[] testServers = new String[] {"nats://localhost:1222",
             "nats://localhost:1223", "nats://localhost:1224", "nats://localhost:1225",
             "nats://localhost:1226", "nats://localhost:1227", "nats://localhost:1228"};

--- a/src/it/java/io/nats/client/ITConnectionTest.java
+++ b/src/it/java/io/nats/client/ITConnectionTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2015-2016 Apcera Inc. All rights reserved. This program and the accompanying
+ *  Copyright (c) 2015-2017 Apcera Inc. All rights reserved. This program and the accompanying
  *  materials are made available under the terms of the MIT License (MIT) which accompanies this
  *  distribution, and is available at http://opensource.org/licenses/MIT
  */
@@ -23,16 +23,11 @@ import static org.junit.Assert.fail;
 
 import io.nats.client.ConnectionImpl.Srv;
 import org.hamcrest.core.IsNot;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -46,31 +41,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 @Category(IntegrationTest.class)
-public class ITConnectionTest {
-
+public class ITConnectionTest extends ITBaseTest {
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
-    @Rule
-    public TestCasePrinterRule pr = new TestCasePrinterRule(System.out);
-
     ExecutorService executor = Executors.newFixedThreadPool(5);
-
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-    }
-
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-    }
-
-    @Before
-    public void setUp() throws Exception {
-    }
-
-    @After
-    public void tearDown() throws Exception {
-    }
 
     @Test
     public void testDefaultConnection() throws Exception {

--- a/src/it/java/io/nats/client/ITReconnectTest.java
+++ b/src/it/java/io/nats/client/ITReconnectTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2015-2016 Apcera Inc. All rights reserved. This program and the accompanying
+ *  Copyright (c) 2015-2017 Apcera Inc. All rights reserved. This program and the accompanying
  *  materials are made available under the terms of the MIT License (MIT) which accompanies this
  *  distribution, and is available at http://opensource.org/licenses/MIT
  */
@@ -16,11 +16,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -33,28 +28,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 @Category(IntegrationTest.class)
-public class ITReconnectTest {
-
-    @Rule
-    public TestCasePrinterRule pr = new TestCasePrinterRule(System.out);
+public class ITReconnectTest extends ITBaseTest {
 
     private final Properties reconnectOptions = getReconnectOptions();
-
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-    }
-
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-    }
-
-    @Before
-    public void setUp() throws Exception {
-    }
-
-    @After
-    public void tearDown() throws Exception {
-    }
 
     private static Properties getReconnectOptions() {
         Properties props = new Properties();

--- a/src/it/java/io/nats/client/ITSubscriptionTest.java
+++ b/src/it/java/io/nats/client/ITSubscriptionTest.java
@@ -1204,7 +1204,7 @@ public class ITSubscriptionTest extends ITBaseTest {
 
     @Test
     public void testExceptionInOnMessage() throws Exception {
-        // Shutdown message delivery pool if set.
+        // This test need to control when/if thread pool need to be created and if so what size.
         Nats.shutdownMsgDeliveryThreadPool();
 
         final byte[] payload = "hello".getBytes();
@@ -1236,15 +1236,18 @@ public class ITSubscriptionTest extends ITBaseTest {
                 } // conn
             } // server
 
-            // Repeat the test with message delivery pool
-            Nats.setMsgDeliveryThreadPoolSize(1);
+            if (tests == 0) {
+                // Repeat the test with message delivery pool
+                Nats.createMsgDeliveryThreadPool(1);
+            }
         }
     }
 
     @Test
     public void testCheckMsgDispatchedFromGlobalMsgDeliveryThreadPool() throws Exception {
-        // Ensure we are running with a message delivery thread pool.
-        Nats.setMsgDeliveryThreadPoolSize(1);
+        // Control existence/size of pool by shuting it down and create again.
+        Nats.shutdownMsgDeliveryThreadPool();
+        Nats.createMsgDeliveryThreadPool(1);
 
         final byte[] payload = "hello".getBytes();
 
@@ -1287,10 +1290,9 @@ public class ITSubscriptionTest extends ITBaseTest {
 
     @Test
     public void testAsyncSubsSharingSameGlobalMsgDeliveryThread() throws Exception {
-        // For this test, manually control the msg delivery pool
+        // Control existence/size of pool by shuting it down and create again.
         Nats.shutdownMsgDeliveryThreadPool();
-        // Set size 1.
-        Nats.setMsgDeliveryThreadPoolSize(1);
+        Nats.createMsgDeliveryThreadPool(1);
 
         final byte[] payload = "hello".getBytes();
         final CountDownLatch latch = new CountDownLatch(3);
@@ -1369,10 +1371,9 @@ public class ITSubscriptionTest extends ITBaseTest {
 
     @Test
     public void testAsyncSubsWithGlobalMsgDeliveryPool() throws Exception {
-        // For this test, manually control the msg delivery pool
+        // Control existence/size of pool by shuting it down and create again.
         Nats.shutdownMsgDeliveryThreadPool();
-        // Set size 2
-        Nats.setMsgDeliveryThreadPoolSize(2);
+        Nats.createMsgDeliveryThreadPool(2);
 
         final CountDownLatch latch = new CountDownLatch(2);
         final int toSend = 10000;
@@ -1426,10 +1427,9 @@ public class ITSubscriptionTest extends ITBaseTest {
 
     @Test
     public void testAsyncSubWithGlobalMsgDeliveryPoolConnectionCloseInMsgCallback() throws Throwable {
-        // For this test, manually control the msg delivery pool
+        // Control existence/size of pool by shuting it down and create again.
         Nats.shutdownMsgDeliveryThreadPool();
-        // Set size 2
-        Nats.setMsgDeliveryThreadPoolSize(2);
+        Nats.createMsgDeliveryThreadPool(2);
 
         final byte[] payload = "hello".getBytes();
         final AtomicInteger received = new AtomicInteger(0);
@@ -1458,10 +1458,9 @@ public class ITSubscriptionTest extends ITBaseTest {
 
     @Test
     public void testAsyncSubWithGlobalMsgDeliveryPoolUnsubscribeInMsgCallback() throws Throwable {
-        // For this test, manually control the msg delivery pool
+        // Control existence/size of pool by shuting it down and create again.
         Nats.shutdownMsgDeliveryThreadPool();
-        // Set size 2
-        Nats.setMsgDeliveryThreadPoolSize(2);
+        Nats.createMsgDeliveryThreadPool(2);
 
         final byte[] payload = "hello".getBytes();
         final AtomicInteger received = new AtomicInteger(0);

--- a/src/it/java/io/nats/client/ITTLSTest.java
+++ b/src/it/java/io/nats/client/ITTLSTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2015-2016 Apcera Inc. All rights reserved. This program and the accompanying
+ *  Copyright (c) 2015-2017 Apcera Inc. All rights reserved. This program and the accompanying
  *  materials are made available under the terms of the MIT License (MIT) which accompanies this
  *  distribution, and is available at http://opensource.org/licenses/MIT
  */
@@ -18,21 +18,11 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import java.io.IOException;
-import java.security.KeyManagementException;
 import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
-import java.security.cert.CertificateException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -41,28 +31,9 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
 
 @Category(IntegrationTest.class)
-public class ITTLSTest {
-    @Rule
-    public TestCasePrinterRule pr = new TestCasePrinterRule(System.out);
+public class ITTLSTest extends ITBaseTest {
 
     UnitTestUtilities utils = new UnitTestUtilities();
-
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-    }
-
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-    }
-
-    @Before
-    public void setUp() throws Exception {
-
-    }
-
-    @After
-    public void tearDown() throws Exception {
-    }
 
     @Test
     public void testTlsSuccessWithCert() throws Exception {

--- a/src/main/java/io/nats/client/AsyncSubscriptionImpl.java
+++ b/src/main/java/io/nats/client/AsyncSubscriptionImpl.java
@@ -12,7 +12,8 @@ package io.nats.client;
  */
 class AsyncSubscriptionImpl extends SubscriptionImpl implements AsyncSubscription {
 
-    private MessageHandler msgHandler;
+    private MessageHandler    msgHandler;
+    private MsgDeliveryWorker dlvWorker;
 
     AsyncSubscriptionImpl(ConnectionImpl nc, String subj, String queue,
                           MessageHandler cb) {
@@ -33,12 +34,138 @@ class AsyncSubscriptionImpl extends SubscriptionImpl implements AsyncSubscriptio
 
     @Override
     public void setMessageHandler(MessageHandler cb) {
+        this.dlvWorkerLock();
         this.msgHandler = cb;
+        this.dlvWorkerUnlock();
     }
 
     @Override
     public MessageHandler getMessageHandler() {
-        return msgHandler;
+        this.dlvWorkerLock();
+        try {
+            return msgHandler;
+        } finally {
+            this.dlvWorkerUnlock();
+        }
     }
 
+    @Override
+    public long getDelivered() {
+        this.dlvWorkerLock();
+        try {
+            return super.getDelivered();
+        } finally {
+            this.dlvWorkerUnlock();
+        }
+    }
+
+    @Override
+    public int getPendingMsgs() {
+        this.dlvWorkerLock();
+        try {
+            return super.getPendingMsgs();
+        } finally {
+            this.dlvWorkerUnlock();
+        }
+    }
+
+    @Override
+    public int getPendingBytes() {
+        this.dlvWorkerLock();
+        try {
+            return super.getPendingBytes();
+        } finally {
+            this.dlvWorkerUnlock();
+        }
+    }
+
+    @Override
+    public int getPendingMsgsMax() {
+        this.dlvWorkerLock();
+        try {
+            return super.getPendingMsgsMax();
+        } finally {
+            this.dlvWorkerUnlock();
+        }
+    }
+
+    @Override
+    public long getPendingBytesMax() {
+        this.dlvWorkerLock();
+        try {
+            return super.getPendingBytesMax();
+        } finally {
+            this.dlvWorkerUnlock();
+        }
+    }
+
+    @Override
+    public void setPendingLimits(int msgs, int bytes) {
+        this.dlvWorkerLock();
+        try {
+            super.setPendingLimits(msgs, bytes);
+        } finally {
+            this.dlvWorkerUnlock();
+        }
+    }
+
+    @Override
+    public int getPendingMsgsLimit() {
+        this.dlvWorkerLock();
+        try {
+            return super.getPendingMsgsLimit();
+        } finally {
+            this.dlvWorkerUnlock();
+        }
+    }
+
+    @Override
+    public void clearMaxPending() {
+        this.dlvWorkerLock();
+        try {
+            super.clearMaxPending();
+        } finally {
+            this.dlvWorkerUnlock();
+        }
+    }
+
+    @Override
+    public int getDropped() {
+        this.dlvWorkerLock();
+        try {
+            return super.getDropped();
+        } finally {
+            this.dlvWorkerUnlock();
+        }
+    }
+
+    @Override
+    public void close() {
+        this.dlvWorkerLock();
+        try {
+            super.close();
+        } finally {
+            this.dlvWorkerUnlock();
+        }
+    }
+
+    private void dlvWorkerLock() {
+        if (this.dlvWorker != null) {
+            this.dlvWorker.lock();
+        }
+    }
+
+    private void dlvWorkerUnlock() {
+        if (this.dlvWorker != null) {
+            this.dlvWorker.unlock();
+        }
+    }
+
+    MsgDeliveryWorker getDeliveryWorker() {
+        return this.dlvWorker;
+    }
+
+    void setDeliveryWorker(MsgDeliveryWorker worker) {
+        this.dlvWorker = worker;
+    }
 }

--- a/src/main/java/io/nats/client/AsyncSubscriptionImpl.java
+++ b/src/main/java/io/nats/client/AsyncSubscriptionImpl.java
@@ -42,11 +42,9 @@ class AsyncSubscriptionImpl extends SubscriptionImpl implements AsyncSubscriptio
     @Override
     public MessageHandler getMessageHandler() {
         this.dlvWorkerLock();
-        try {
-            return msgHandler;
-        } finally {
-            this.dlvWorkerUnlock();
-        }
+        MessageHandler mh = msgHandler;
+        this.dlvWorkerUnlock();
+        return mh;
     }
 
     @Override

--- a/src/main/java/io/nats/client/AsyncSubscriptionImpl.java
+++ b/src/main/java/io/nats/client/AsyncSubscriptionImpl.java
@@ -16,7 +16,12 @@ class AsyncSubscriptionImpl extends SubscriptionImpl implements AsyncSubscriptio
 
     AsyncSubscriptionImpl(ConnectionImpl nc, String subj, String queue,
                           MessageHandler cb) {
-        super(nc, subj, queue);
+        this(nc, subj, queue, cb, false);
+    }
+
+    AsyncSubscriptionImpl(ConnectionImpl nc, String subj, String queue,
+                          MessageHandler cb, boolean useMsgDlvPool) {
+        super(nc, subj, queue, DEFAULT_MAX_PENDING_MSGS, DEFAULT_MAX_PENDING_BYTES, useMsgDlvPool);
         this.msgHandler = cb;
     }
 

--- a/src/main/java/io/nats/client/AsyncSubscriptionImpl.java
+++ b/src/main/java/io/nats/client/AsyncSubscriptionImpl.java
@@ -12,8 +12,8 @@ package io.nats.client;
  */
 class AsyncSubscriptionImpl extends SubscriptionImpl implements AsyncSubscription {
 
-    private MessageHandler    msgHandler;
-    private MsgDeliveryWorker dlvWorker;
+    MessageHandler    msgHandler;
+    MsgDeliveryWorker dlvWorker;
 
     AsyncSubscriptionImpl(ConnectionImpl nc, String subj, String queue,
                           MessageHandler cb) {
@@ -138,10 +138,20 @@ class AsyncSubscriptionImpl extends SubscriptionImpl implements AsyncSubscriptio
     }
 
     @Override
-    public void close() {
+    void setMax(long max) {
         this.dlvWorkerLock();
         try {
-            super.close();
+            super.setMax(max);
+        } finally {
+            this.dlvWorkerUnlock();
+        }
+    }
+
+    @Override
+    void close(boolean connClosed) {
+        this.dlvWorkerLock();
+        try {
+            super.close(connClosed);
         } finally {
             this.dlvWorkerUnlock();
         }

--- a/src/main/java/io/nats/client/ConnectionFactory.java
+++ b/src/main/java/io/nats/client/ConnectionFactory.java
@@ -56,6 +56,7 @@ public class ConnectionFactory {
     private ReconnectedCallback reconnectedCallback;
     private String urlString = null;
     private boolean tlsDebug;
+    private boolean useGlobalMsgDelivery = false;
 
     /**
      * Constructs a new connection factory from a {@link Properties} object.
@@ -101,6 +102,7 @@ public class ConnectionFactory {
         this.disconnectedCallback = opts.disconnectedCb;
         this.reconnectedCallback = opts.reconnectedCb;
         this.factory = opts.factory;
+        this.useGlobalMsgDelivery = opts.useGlobalMsgDelivery;
     }
 
     /**
@@ -183,6 +185,7 @@ public class ConnectionFactory {
         this.reconnectedCallback = cf.reconnectedCallback;
         this.urlString = cf.urlString;
         this.tlsDebug = cf.tlsDebug;
+        this.useGlobalMsgDelivery = cf.useGlobalMsgDelivery;
     }
 
     @Override
@@ -191,7 +194,7 @@ public class ConnectionFactory {
                 connectionName, verbose, pedantic, secure, reconnectAllowed, maxReconnect,
                 reconnectBufSize, reconnectWait, connectionTimeout, pingInterval, maxPingsOut,
                 sslContext, exceptionHandler, closedCallback, disconnectedCallback,
-                reconnectedCallback, urlString, tlsDebug);
+                reconnectedCallback, urlString, tlsDebug, useGlobalMsgDelivery);
     }
 
     @Override
@@ -274,6 +277,9 @@ public class ConnectionFactory {
         }
         if (!reconnectAllowed) {
             result = result.noReconnect();
+        }
+        if (useGlobalMsgDelivery) {
+            result = result.useGlobalMsgDelivery(true);
         }
 
         result = result.factory(factory).maxReconnect(maxReconnect).reconnectWait(reconnectWait)
@@ -880,5 +886,27 @@ public class ConnectionFactory {
      */
     public final void setSSLContext(SSLContext ctx) {
         this.sslContext = ctx;
+    }
+
+    /**
+     * Sets whether the connection's asynchronous subscriptions should
+     * use the global message delivery thread pool.
+     *
+     * See {@link Nats#setMsgDeliveryThreadPoolSize(int)} for more information.
+     *
+     * @param usePool whether to use the global thread pool or not.
+     */
+    public final void setUseGlobalMessageDelivery(boolean usePool) {
+        this.useGlobalMsgDelivery = usePool;
+    }
+
+    /**
+     * Indicates whether the connection's asynchronous subscriptions will use
+     * the global message delivery thread pool.
+     *
+     * @return {@code true} if using global message delivery, otherwise {@code false}
+     */
+    public final boolean isUsingGlobalMessageDelivery() {
+        return this.useGlobalMsgDelivery;
     }
 }

--- a/src/main/java/io/nats/client/ConnectionFactory.java
+++ b/src/main/java/io/nats/client/ConnectionFactory.java
@@ -892,7 +892,7 @@ public class ConnectionFactory {
      * Sets whether the connection's asynchronous subscriptions should
      * use the global message delivery thread pool.
      *
-     * See {@link Nats#setMsgDeliveryThreadPoolSize(int)} for more information.
+     * See {@link Nats#createMsgDeliveryThreadPool(int)} for more information.
      *
      * @param usePool whether to use the global thread pool or not.
      */

--- a/src/main/java/io/nats/client/ConnectionImpl.java
+++ b/src/main/java/io/nats/client/ConnectionImpl.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2015-2016 Apcera Inc. All rights reserved. This program and the accompanying
+ *  Copyright (c) 2015-2017 Apcera Inc. All rights reserved. This program and the accompanying
  *  materials are made available under the terms of the MIT License (MIT) which accompanies this
  *  distribution, and is available at http://opensource.org/licenses/MIT
  */
@@ -25,7 +25,6 @@ import static io.nats.client.Nats.ERR_SECURE_CONN_REQUIRED;
 import static io.nats.client.Nats.ERR_SECURE_CONN_WANTED;
 import static io.nats.client.Nats.ERR_SLOW_CONSUMER;
 import static io.nats.client.Nats.ERR_STALE_CONNECTION;
-import static io.nats.client.Nats.ERR_TCP_FLUSH_FAILED;
 import static io.nats.client.Nats.ERR_TIMEOUT;
 import static io.nats.client.Nats.PERMISSIONS_ERR;
 import static io.nats.client.Nats.TLS_SCHEME;
@@ -1417,7 +1416,8 @@ class ConnectionImpl implements Connection {
             }
             // Deliver the message.
             if (msg != null && (max <= 0 || delivered <= max)) {
-                mcb.onMessage(msg);
+                // Ignore any error thrown by the user
+                try { mcb.onMessage(msg); } catch (Throwable t) {}
             }
             // If we have hit the max for delivered msgs, remove sub.
             if (max > 0 && delivered >= max) {
@@ -1458,7 +1458,12 @@ class ConnectionImpl implements Connection {
             // It's possible that we end up not using the message, but that's ok.
             Message msg = new Message(parser.ps.ma, sub, data, offset, length);
 
-            sub.lock();
+            final MsgDeliveryWorker mdw = sub.getDeliveryWorker();
+            if (mdw != null) {
+                mdw.lock();
+            } else {
+                sub.lock();
+            }
             try {
                 sub.pMsgs++;
                 if (sub.pMsgs > sub.pMsgsMax) {
@@ -1474,19 +1479,27 @@ class ConnectionImpl implements Connection {
                         || (sub.pBytesLimit > 0 && sub.pBytes > sub.pBytesLimit)) {
                     handleSlowConsumer(sub, msg);
                 } else {
-                    // We use mch for everything, unlike Go client
-                    if (sub.getChannel() != null) {
-                        if (sub.getChannel().add(msg)) {
-                            sub.pCond.signal();
-                            // Clear Slow Consumer status
-                            sub.setSlowConsumer(false);
-                        } else {
-                            handleSlowConsumer(sub, msg);
+                    if (mdw != null) {
+                        mdw.postMsg(msg);
+                    } else {
+                        // We use mch for everything, unlike Go client
+                        if (sub.getChannel() != null) {
+                            if (sub.getChannel().add(msg)) {
+                                sub.pCond.signal();
+                                // Clear Slow Consumer status
+                                sub.setSlowConsumer(false);
+                            } else {
+                                handleSlowConsumer(sub, msg);
+                            }
                         }
                     }
                 }
             } finally {
-                sub.unlock();
+                if (mdw != null) {
+                    mdw.unlock();
+                } else {
+                    sub.unlock();
+                }
             }
         } finally {
             mu.unlock();
@@ -1811,18 +1824,27 @@ class ConnectionImpl implements Connection {
             }
 
             if (cb != null) {
-                sub = new AsyncSubscriptionImpl(this, subject, queue, cb);
-                // If we have an async callback, start up a sub specific Runnable to deliver the
-                // messages
-                subexec.submit(new Runnable() {
-                    public void run() {
-                        try {
-                            waitForMsgs((AsyncSubscriptionImpl) sub);
-                        } catch (InterruptedException e) {
-                            Thread.currentThread().interrupt();
+                // Check if we should use the global message delivery pool or create our own thread.
+                MsgDeliveryPool msgDlvPool = null;
+                final boolean   useDlvPool = (this.opts.useGlobalMsgDelivery &&
+                                                ((msgDlvPool = Nats.getMsgDeliveryThreadPool()) != null));
+
+                sub = new AsyncSubscriptionImpl(this, subject, queue, cb, useDlvPool);
+                if (useDlvPool) {
+                    msgDlvPool.assignDeliveryWorker(sub);
+                } else {
+                    // If we have an async callback, start up a sub specific Runnable to deliver the
+                    // messages
+                    subexec.submit(new Runnable() {
+                        public void run() {
+                            try {
+                                waitForMsgs((AsyncSubscriptionImpl) sub);
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                            }
                         }
-                    }
-                });
+                    });
+                }
             } else {
                 sub = new SyncSubscriptionImpl(this, subject, queue);
                 sub.setChannel(ch);
@@ -1856,24 +1878,24 @@ class ConnectionImpl implements Connection {
 
     @Override
     public AsyncSubscription subscribe(String subject, MessageHandler cb) {
-        return subscribe(subject, null, cb);
+        return (AsyncSubscription) subscribe(subject, null, cb);
     }
 
     @Override
     public AsyncSubscription subscribe(String subj, String queue, MessageHandler cb) {
-        return (AsyncSubscriptionImpl) subscribe(subj, queue, cb, null);
+        return (AsyncSubscription) subscribe(subj, queue, cb, null);
     }
 
     @Override
     @Deprecated
     public AsyncSubscription subscribeAsync(String subject, String queue, MessageHandler cb) {
-        return (AsyncSubscriptionImpl) subscribe(subject, queue, cb, null);
+        return (AsyncSubscription) subscribe(subject, queue, cb, null);
     }
 
     @Override
     @Deprecated
     public AsyncSubscription subscribeAsync(String subj, MessageHandler cb) {
-        return subscribe(subj, null, cb);
+        return (AsyncSubscription) subscribe(subj, null, cb);
     }
 
     private void addSubscription(SubscriptionImpl sub) {

--- a/src/main/java/io/nats/client/ConnectionImpl.java
+++ b/src/main/java/io/nats/client/ConnectionImpl.java
@@ -1377,9 +1377,8 @@ class ConnectionImpl implements Connection {
      * deliver messages to asynchronous subscribers.
      *
      * @param sub the asynchronous subscriber
-     * @throws InterruptedException if the thread is interrupted
      */
-    void waitForMsgs(AsyncSubscriptionImpl sub) throws InterruptedException {
+    void waitForMsgs(AsyncSubscriptionImpl sub) {
         boolean closed;
         long delivered = 0L;
         long max;
@@ -1392,7 +1391,7 @@ class ConnectionImpl implements Connection {
             try {
                 mch = sub.getChannel();
                 while (mch.size() == 0 && !sub.isClosed()) {
-                    sub.pCond.await();
+                    try { sub.pCond.await(); } catch (InterruptedException e) {}
                 }
                 msg = mch.poll();
                 if (msg != null) {
@@ -1840,11 +1839,7 @@ class ConnectionImpl implements Connection {
                     // messages
                     subexec.submit(new Runnable() {
                         public void run() {
-                            try {
-                                waitForMsgs((AsyncSubscriptionImpl) sub);
-                            } catch (InterruptedException e) {
-                                Thread.currentThread().interrupt();
-                            }
+                            waitForMsgs((AsyncSubscriptionImpl) sub);
                         }
                     });
                 }

--- a/src/main/java/io/nats/client/ConnectionImpl.java
+++ b/src/main/java/io/nats/client/ConnectionImpl.java
@@ -1458,7 +1458,10 @@ class ConnectionImpl implements Connection {
             // It's possible that we end up not using the message, but that's ok.
             Message msg = new Message(parser.ps.ma, sub, data, offset, length);
 
-            final MsgDeliveryWorker mdw = sub.getDeliveryWorker();
+            MsgDeliveryWorker mdw = null;
+            if (sub instanceof AsyncSubscriptionImpl) {
+                mdw = ((AsyncSubscriptionImpl) sub).getDeliveryWorker();
+            }
             if (mdw != null) {
                 mdw.lock();
             } else {
@@ -1831,7 +1834,7 @@ class ConnectionImpl implements Connection {
 
                 sub = new AsyncSubscriptionImpl(this, subject, queue, cb, useDlvPool);
                 if (useDlvPool) {
-                    msgDlvPool.assignDeliveryWorker(sub);
+                    msgDlvPool.assignDeliveryWorker((AsyncSubscriptionImpl) sub);
                 } else {
                     // If we have an async callback, start up a sub specific Runnable to deliver the
                     // messages

--- a/src/main/java/io/nats/client/MsgDeliveryPool.java
+++ b/src/main/java/io/nats/client/MsgDeliveryPool.java
@@ -17,31 +17,17 @@ class MsgDeliveryPool {
     private int                     idx;
     private boolean                 shutdown;
 
-    // Expand the pool of workers.
-    // This call has no effect for a size lower to 1 or if given size
-    // is lower or equal to current pool size.
-    synchronized void setSize(int size) {
-        if (size <= 0) {
-            return;
-        }
-        if (this.workers == null) {
-            this.workers = new ArrayList<MsgDeliveryWorker>(size);
-        }
-        // We support only expansion of the pool at this point
-        if (size > this.workers.size()) {
-            final int added = size-this.workers.size();
-            for (int i=0; i<added; i++) {
-                MsgDeliveryWorker w = new MsgDeliveryWorker();
-                w.start();
-                this.workers.add(w);
-            }
+    // Size is guaranteed to be >= 1 by caller.
+    MsgDeliveryPool(int size) {
+        this.workers = new ArrayList<MsgDeliveryWorker>(size);
+        for (int i=0; i<size; i++) {
+            MsgDeliveryWorker w = new MsgDeliveryWorker();
+            w.start();
+            this.workers.add(w);
         }
     }
 
     synchronized int getSize() {
-        if (this.workers == null) {
-            return 0;
-        }
         return this.workers.size();
     }
 

--- a/src/main/java/io/nats/client/MsgDeliveryPool.java
+++ b/src/main/java/io/nats/client/MsgDeliveryPool.java
@@ -42,7 +42,7 @@ class MsgDeliveryPool {
         return this.workers.size();
     }
 
-    synchronized void assignDeliveryWorker(SubscriptionImpl sub) {
+    synchronized void assignDeliveryWorker(AsyncSubscriptionImpl sub) {
         int idx = this.idx;
         if (++this.idx >= this.workers.size()) {
             this.idx = 0;
@@ -139,7 +139,12 @@ class MsgDeliveryWorker extends Thread {
             if ((max > 0) && (delivered >= max))
             {
                 // If we have hit the max for delivered msgs, remove sub.
-                nc.removeSub(sub);
+                nc.mu.lock();
+                try {
+                    nc.removeSub(sub);
+                } finally {
+                    nc.mu.unlock();
+                }
             }
 
             this.mu.lock();

--- a/src/main/java/io/nats/client/MsgDeliveryPool.java
+++ b/src/main/java/io/nats/client/MsgDeliveryPool.java
@@ -1,0 +1,174 @@
+/*
+ *  Copyright (c) 2017 Apcera Inc. All rights reserved. This program and the accompanying
+ *  materials are made available under the terms of the MIT License (MIT) which accompanies this
+ *  distribution, and is available at http://opensource.org/licenses/MIT
+ */
+
+package io.nats.client;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.locks.*;
+
+
+class MsgDeliveryPool {
+    private List<MsgDeliveryWorker> workers = null;
+    private int                     idx;
+    private boolean                 shutdown;
+
+    // Expand the pool of workers.
+    // This call has no effect for a size lower to 1 or if given size
+    // is lower or equal to current pool size.
+    synchronized void setSize(int size) {
+        if (size <= 0) {
+            return;
+        }
+        if (this.workers == null) {
+            this.workers = new ArrayList<MsgDeliveryWorker>(size);
+        }
+        // We support only expansion of the pool at this point
+        if (size > this.workers.size()) {
+            final int added = size-this.workers.size();
+            for (int i=0; i<added; i++) {
+                MsgDeliveryWorker w = new MsgDeliveryWorker();
+                w.start();
+                this.workers.add(w);
+            }
+        }
+    }
+
+    synchronized int getSize() {
+        return this.workers.size();
+    }
+
+    synchronized void assignDeliveryWorker(SubscriptionImpl sub) {
+        int idx = this.idx;
+        if (++this.idx >= this.workers.size()) {
+            this.idx = 0;
+        }
+        final MsgDeliveryWorker worker = this.workers.get(idx);
+        sub.setDeliveryWorker(worker);
+    }
+
+    synchronized void shutdown() {
+        if (this.shutdown) {
+            return;
+        }
+        this.shutdown = true;
+        for (int i=0; i<this.workers.size(); i++) {
+            final MsgDeliveryWorker w = this.workers.get(i);
+            w.shutdown();
+        }
+        this.workers.clear();
+    }
+}
+
+class MsgDeliveryWorker extends Thread {
+    private final Lock          mu       = new ReentrantLock();
+    private final List<Message> msgs     = new LinkedList<Message>();
+    private final Condition     cond     = mu.newCondition();
+    private boolean             inWait   = false;
+    private boolean             shutdown = false;
+
+    MsgDeliveryWorker() {
+        this.setName("jnats-msg-delivery-worker-thread");
+    }
+
+    // Add a message to the list and signal the worker thread.
+    // Lock is assumed held on entry.
+    void postMsg(Message msg) {
+        this.msgs.add(msg);
+        if (this.inWait) {
+            this.cond.signal();
+        }
+    }
+
+    @Override
+    public void run() {
+        Message msg = null;
+        AsyncSubscriptionImpl sub = null;
+        ConnectionImpl nc = null;
+        MessageHandler mcb = null;
+        long max = 0;
+        long delivered = 0;
+
+        this.mu.lock();
+        while (true) {
+            while (this.msgs.isEmpty() && !this.shutdown) {
+                this.inWait = true;
+                try { this.cond.await(); } catch (InterruptedException e) {}
+                this.inWait = false;
+            }
+            // Exit only when all messages have been dispatched
+            if (this.msgs.isEmpty() && this.shutdown) {
+                break;
+            }
+            // Remove first message from list.
+            msg = this.msgs.remove(0);
+
+            // Get subscription reference from message
+            sub = (AsyncSubscriptionImpl) msg.getSubscription();
+
+            // Capture these under lock
+            nc = (ConnectionImpl) sub.getConnection();
+            mcb = sub.getMessageHandler();
+            max = sub.max;
+
+            sub.pMsgs--;
+            sub.pBytes -= (msg.getData() == null ? 0 : msg.getData().length);
+
+            // If sub is closed, simply go back at beginning of loop.
+            if (sub.closed) {
+                continue;
+            }
+
+            delivered = ++(sub.delivered);
+            this.mu.unlock();
+
+            if ((max == 0) || (delivered <= max)) {
+                try {
+                    mcb.onMessage(msg);
+                } catch (Throwable t) {
+                    // Ignore any exception thrown in the user callback.
+                }
+            }
+
+            // Don't do 'else' because we need to remove when we have hit
+            // the max (after the callback returns).
+            if ((max > 0) && (delivered >= max))
+            {
+                // If we have hit the max for delivered msgs, remove sub.
+                nc.removeSub(sub);
+            }
+
+            this.mu.lock();
+        }
+        this.mu.unlock();
+    }
+
+    void shutdown() {
+        this.mu.lock();
+        if (this.shutdown) {
+            this.mu.unlock();
+            return;
+        }
+        this.shutdown = true;
+        if (this.inWait) {
+            this.cond.signal();
+        }
+        this.mu.unlock();
+
+        if (Thread.currentThread() != this) {
+            try { this.join(); } catch (InterruptedException e) {}
+        }
+    }
+
+    void lock() {
+        this.mu.lock();
+    }
+
+    void unlock() {
+        this.mu.unlock();
+    }
+}

--- a/src/main/java/io/nats/client/MsgDeliveryPool.java
+++ b/src/main/java/io/nats/client/MsgDeliveryPool.java
@@ -105,8 +105,8 @@ class MsgDeliveryWorker extends Thread {
             }
 
             // Capture these under lock
-            nc = (ConnectionImpl) sub.getConnection();
-            mcb = sub.getMessageHandler();
+            nc = sub.conn;
+            mcb = sub.msgHandler;
             max = sub.max;
 
             sub.pMsgs--;

--- a/src/main/java/io/nats/client/Nats.java
+++ b/src/main/java/io/nats/client/Nats.java
@@ -492,7 +492,8 @@ public final class Nats {
      * Sets the message delivery thread pool size.
      *
      * By default, each asynchronous subscription has its own thread
-     * responsible to dispatch the subscription's messages.
+     * responsible for dispatching the messages.
+     *
      * If the application needs to create a high number of subscriptions,
      * this may not scale.
      *
@@ -501,6 +502,10 @@ public final class Nats {
      * thread pool still guarantees that messages from a given subscription
      * are dispatched in order. In other words, a subscription is bound
      * to a given thread in the pool.
+     *
+     * Currently, the pool can be expanded but will not shrink if you
+     * call {@link #setMsgDeliveryThreadPoolSize(int)} with a lower
+     * value than the previous call (but will not report any error).
      *
      * @param size the size of the thread pool
      */
@@ -530,10 +535,11 @@ public final class Nats {
     /**
      * Shuts down the message delivery thread pool.
      *
-     * This call will block until all messages have been dispatched.
-     * If called, this should be called only after all connections have been
-     * closed so that no new messages arrive and need to be dipatched, which would
-     * delay the shutdown of the thread pool.
+     * The pool is shared by all connections. You don't need to
+     * call {@link #shutdownMsgDeliveryThreadPool()}, but if you do,
+     * you should call this method only after all connections have been
+     * closed to ensure that no new message arrive and need to be
+     * dipatched, which would delay the shutdown of the thread pool.
      */
     synchronized public static void shutdownMsgDeliveryThreadPool() {
         if (globalMsgDeliveryPool == null) {

--- a/src/main/java/io/nats/client/Nats.java
+++ b/src/main/java/io/nats/client/Nats.java
@@ -508,6 +508,7 @@ public final class Nats {
      * value than the previous call (but will not report any error).
      *
      * @param size the size of the thread pool
+     * @throws IllegalArgumentException if size is lower or equal to zero.
      */
     synchronized public static void setMsgDeliveryThreadPoolSize(int size) {
         if (size <= 0) {

--- a/src/main/java/io/nats/client/Subscription.java
+++ b/src/main/java/io/nats/client/Subscription.java
@@ -70,7 +70,7 @@ public interface Subscription extends AutoCloseable {
      * Returns the number of messages delivered to, but not processed, by this Subscription.
      *
      * @return the number of delivered messages.
-     * @deprecated use getPending instead
+     * @deprecated use {@link #getPendingMsgs()} instead
      */
     @Deprecated
     int getQueuedMessageCount();

--- a/src/main/java/io/nats/client/SubscriptionImpl.java
+++ b/src/main/java/io/nats/client/SubscriptionImpl.java
@@ -51,10 +51,6 @@ abstract class SubscriptionImpl implements Subscription {
     BlockingQueue<Message> mch;
     Condition pCond;
 
-    // Ideally, this should be in AsyncSubscriptionImpl, but because of
-    // locking and to reduce code duplication, leave this here.
-    private MsgDeliveryWorker dlvWorker;
-
     // Pending stats, async subscriptions, high-speed etc.
     int pMsgs;
     int pBytes;
@@ -187,9 +183,7 @@ abstract class SubscriptionImpl implements Subscription {
             if (conn == null) {
                 throw new IllegalStateException(ERR_BAD_SUBSCRIPTION);
             }
-            this.dlvWorkerLock();
             rv = dropped;
-            this.dlvWorkerUnlock();
         } finally {
             mu.unlock();
         }
@@ -204,9 +198,7 @@ abstract class SubscriptionImpl implements Subscription {
             if (conn == null) {
                 throw new IllegalStateException(ERR_BAD_SUBSCRIPTION);
             }
-            this.dlvWorkerLock();
             rv = this.pMsgsMax;
-            this.dlvWorkerUnlock();
         } finally {
             mu.unlock();
         }
@@ -222,9 +214,7 @@ abstract class SubscriptionImpl implements Subscription {
             if (conn == null) {
                 throw new IllegalStateException(ERR_BAD_SUBSCRIPTION);
             }
-            this.dlvWorkerLock();
             rv = this.pBytesMax;
-            this.dlvWorkerUnlock();
         } finally {
             mu.unlock();
         }
@@ -244,9 +234,7 @@ abstract class SubscriptionImpl implements Subscription {
             if (pendingMsgsLimit == 0) {
                 throw new IllegalArgumentException("nats: pending message limit cannot be zero");
             }
-            this.dlvWorkerLock();
             pMsgsLimit = pendingMsgsLimit;
-            this.dlvWorkerUnlock();
         } finally {
             mu.unlock();
         }
@@ -258,9 +246,7 @@ abstract class SubscriptionImpl implements Subscription {
             if (pendingBytesLimit == 0) {
                 throw new IllegalArgumentException("nats: pending message limit cannot be zero");
             }
-            this.dlvWorkerLock();
             pBytesLimit = pendingBytesLimit;
-            this.dlvWorkerUnlock();
         } finally {
             mu.unlock();
         }
@@ -272,9 +258,7 @@ abstract class SubscriptionImpl implements Subscription {
             if (conn == null) {
                 throw new IllegalStateException(ERR_BAD_SUBSCRIPTION);
             }
-            this.dlvWorkerLock();
             pMsgsMax = (max <= 0) ? 0 : max;
-            this.dlvWorkerUnlock();
         } finally {
             mu.unlock();
         }
@@ -286,9 +270,7 @@ abstract class SubscriptionImpl implements Subscription {
             if (conn == null) {
                 throw new IllegalStateException(ERR_BAD_SUBSCRIPTION);
             }
-            this.dlvWorkerLock();
             pBytesMax = (max <= 0) ? 0 : max;
-            this.dlvWorkerUnlock();
         } finally {
             mu.unlock();
         }
@@ -316,9 +298,7 @@ abstract class SubscriptionImpl implements Subscription {
             if (conn == null) {
                 throw new IllegalStateException(ERR_BAD_SUBSCRIPTION);
             }
-            this.dlvWorkerLock();
             rv = delivered;
-            this.dlvWorkerUnlock();
         } finally {
             mu.unlock();
         }
@@ -333,9 +313,7 @@ abstract class SubscriptionImpl implements Subscription {
             if (conn == null) {
                 throw new IllegalStateException(ERR_BAD_SUBSCRIPTION);
             }
-            this.dlvWorkerLock();
             rv = pBytes;
-            this.dlvWorkerUnlock();
         } finally {
             mu.unlock();
         }
@@ -346,9 +324,7 @@ abstract class SubscriptionImpl implements Subscription {
     public int getPendingBytesLimit() {
         int rv;
         mu.lock();
-        this.dlvWorkerLock();
         rv = pBytesLimit;
-        this.dlvWorkerUnlock();
         mu.unlock();
         return rv;
     }
@@ -361,9 +337,7 @@ abstract class SubscriptionImpl implements Subscription {
             if (conn == null) {
                 throw new IllegalStateException(ERR_BAD_SUBSCRIPTION);
             }
-            this.dlvWorkerLock();
             rv = pMsgs;
-            this.dlvWorkerUnlock();
         } finally {
             mu.unlock();
         }
@@ -374,9 +348,7 @@ abstract class SubscriptionImpl implements Subscription {
     public int getPendingMsgsLimit() {
         int rv;
         mu.lock();
-        this.dlvWorkerLock();
         rv = pMsgsLimit;
-        this.dlvWorkerUnlock();
         mu.unlock();
         return rv;
     }
@@ -418,25 +390,5 @@ abstract class SubscriptionImpl implements Subscription {
 
     void unlock() {
         mu.unlock();
-    }
-
-    private void dlvWorkerLock() {
-        if (this.dlvWorker != null) {
-            this.dlvWorker.lock();
-        }
-    }
-
-    private void dlvWorkerUnlock() {
-        if (this.dlvWorker != null) {
-            this.dlvWorker.unlock();
-        }
-    }
-
-    MsgDeliveryWorker getDeliveryWorker() {
-        return this.dlvWorker;
-    }
-
-    void setDeliveryWorker(MsgDeliveryWorker worker) {
-        this.dlvWorker = worker;
     }
 }

--- a/src/test/java/io/nats/client/AsyncSubscriptionImplTest.java
+++ b/src/test/java/io/nats/client/AsyncSubscriptionImplTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2015-2016 Apcera Inc. All rights reserved. This program and the accompanying
+ *  Copyright (c) 2015-2017 Apcera Inc. All rights reserved. This program and the accompanying
  *  materials are made available under the terms of the MIT License (MIT) which accompanies this
  *  distribution, and is available at http://opensource.org/licenses/MIT
  */
@@ -11,10 +11,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -23,13 +20,10 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 @Category(UnitTest.class)
-public class AsyncSubscriptionImplTest {
+public class AsyncSubscriptionImplTest extends BaseUnitTest {
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
-
-    @Rule
-    public TestCasePrinterRule pr = new TestCasePrinterRule(System.out);
 
     @Mock
     public ConnectionImpl connMock;
@@ -37,16 +31,9 @@ public class AsyncSubscriptionImplTest {
     @Mock
     public MessageHandler mcbMock;
 
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-    }
-
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-    }
-
     @Before
     public void setUp() throws Exception {
+        super.setUp();
         MockitoAnnotations.initMocks(this);
     }
 
@@ -58,22 +45,6 @@ public class AsyncSubscriptionImplTest {
         AsyncSubscriptionImpl sub = new AsyncSubscriptionImpl(connMock, "foo", "bar", mcbMock);
         sub.close();
     }
-
-    // @Test
-    // public void testAsyncSubscriptionImpl() {
-    // fail("Not yet implemented"); // TODO
-    // }
-    //
-    @Test
-    public void testStart() {
-        // Make sure the connection opts aren't null
-        when(connMock.getOptions()).thenReturn(Nats.defaultOptions());
-
-        AsyncSubscriptionImpl sub = new AsyncSubscriptionImpl(connMock, "foo", "bar", mcbMock);
-        // Just for the sake of coverage, even though it's a NOOP
-        sub.start();
-    }
-
 
     @Test
     public void testSetMessageHandler() {

--- a/src/test/java/io/nats/client/BaseUnitTest.java
+++ b/src/test/java/io/nats/client/BaseUnitTest.java
@@ -21,9 +21,7 @@ public class BaseUnitTest implements UnitTest {
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {
         // For Unit tests, ensure that there is no global message delivery
-        // pool set, which could happen if user is running test suite and
-        // environment variable JNATS_MSG_DELIVERY_THREAD_POOL_SIZE happens
-        // to be set.
+        // pool set.
         Nats.shutdownMsgDeliveryThreadPool();
     }
 

--- a/src/test/java/io/nats/client/BaseUnitTest.java
+++ b/src/test/java/io/nats/client/BaseUnitTest.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2017 Apcera Inc. All rights reserved. This program and the accompanying
+ *  materials are made available under the terms of the MIT License (MIT) which accompanies this
+ *  distribution, and is available at http://opensource.org/licenses/MIT
+ */
+
+package io.nats.client;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.experimental.categories.Category;
+
+@Category(UnitTest.class)
+public class BaseUnitTest implements UnitTest {
+    @Rule
+    public TestCasePrinterRule pr = new TestCasePrinterRule(System.out);
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        // For Unit tests, ensure that there is no global message delivery
+        // pool set, which could happen if user is running test suite and
+        // environment variable JNATS_MSG_DELIVERY_THREAD_POOL_SIZE happens
+        // to be set.
+        Nats.shutdownMsgDeliveryThreadPool();
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+    }
+
+    @Before
+    public void setUp() throws Exception {
+    }
+
+    @After
+    public void tearDown() throws Exception {
+    }
+}

--- a/src/test/java/io/nats/client/ConnectionEventTest.java
+++ b/src/test/java/io/nats/client/ConnectionEventTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2015-2016 Apcera Inc. All rights reserved. This program and the accompanying
+ *  Copyright (c) 2015-2017 Apcera Inc. All rights reserved. This program and the accompanying
  *  materials are made available under the terms of the MIT License (MIT) which accompanies this
  *  distribution, and is available at http://opensource.org/licenses/MIT
  */
@@ -8,10 +8,7 @@ package io.nats.client;
 
 import static org.junit.Assert.assertEquals;
 
-import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -20,7 +17,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 @Category(UnitTest.class)
-public class ConnectionEventTest {
+public class ConnectionEventTest extends BaseUnitTest {
 
     @Mock
     private Connection connMock;
@@ -28,25 +25,10 @@ public class ConnectionEventTest {
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
-    @Rule
-    public TestCasePrinterRule pr = new TestCasePrinterRule(System.out);
-
-
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-    }
-
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-    }
-
     @Before
     public void setUp() throws Exception {
+        super.setUp();
         MockitoAnnotations.initMocks(this);
-    }
-
-    @After
-    public void tearDown() throws Exception {
     }
 
     @Test

--- a/src/test/java/io/nats/client/ConnectionImplTest.java
+++ b/src/test/java/io/nats/client/ConnectionImplTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2015-2016 Apcera Inc. All rights reserved. This program and the accompanying
+ *  Copyright (c) 2015-2017 Apcera Inc. All rights reserved. This program and the accompanying
  *  materials are made available under the terms of the MIT License (MIT) which accompanies this
  *  distribution, and is available at http://opensource.org/licenses/MIT
  */
@@ -94,13 +94,10 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @Category(UnitTest.class)
 @RunWith(MockitoJUnitRunner.class)
-public class ConnectionImplTest {
+public class ConnectionImplTest extends BaseUnitTest {
 
     @Rule
     public final ExpectedException thrown = ExpectedException.none();
-
-    @Rule
-    public TestCasePrinterRule pr = new TestCasePrinterRule(System.out);
 
     @InjectMocks
     ConnectionImpl connection;
@@ -146,35 +143,6 @@ public class ConnectionImplTest {
 
     @Mock
     private SyncSubscriptionImpl syncSubMock;
-
-    /**
-     * @throws java.lang.Exception if a problem occurs
-     */
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-    }
-
-    /**
-     * @throws java.lang.Exception if a problem occurs
-     */
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-    }
-
-    /**
-     * @throws java.lang.Exception if a problem occurs
-     */
-    @Before
-    public void setUp() throws Exception {
-        //MockitoAnnotations.initMocks(this);
-    }
-
-    /**
-     * @throws java.lang.Exception if a problem occurs
-     */
-    @After
-    public void tearDown() throws Exception {
-    }
 
 //    @SuppressWarnings("resource")
 //    @Test
@@ -1965,11 +1933,11 @@ public class ConnectionImplTest {
         }
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void testResetPingTimer() throws Exception {
         try (ConnectionImpl nc = (ConnectionImpl) spy(newMockedConnection())) {
             ScheduledFuture ptmrMock = mock(ScheduledFuture.class);
-            //noinspection unchecked
             when(nc.createPingTimer()).thenReturn(ptmrMock);
 
             // Test for ptmr already exists

--- a/src/test/java/io/nats/client/ConnectionImplTest.java
+++ b/src/test/java/io/nats/client/ConnectionImplTest.java
@@ -1551,6 +1551,68 @@ public class ConnectionImplTest extends BaseUnitTest {
     }
 
     @Test
+    public void testProcessMsgWithMsgDeliveryPool() throws Exception {
+        final byte[] data = "Hello, World!".getBytes();
+        final int offset = 0;
+        final int length = data.length;
+        final long sid = 4L;
+        final CountDownLatch latch = new CountDownLatch(1);
+        try (ConnectionImpl c = (ConnectionImpl) spy(newMockedConnection())) {
+            Parser parser = c.getParser();
+            AsyncSubscriptionImpl sub = spy(new AsyncSubscriptionImpl(c, "foo", "bar", new MessageHandler(){
+                public void onMessage(Message msg) {
+                    latch.countDown();
+                }
+            }));
+            when(sub.getSid()).thenReturn(sid);
+            parser.ps.ma.sid = sid;
+            parser.ps.ma.size = length;
+            when(subsMock.get(eq(sid))).thenReturn(sub);
+            assertEquals(sub, subsMock.get(sid));
+            c.setSubs(subsMock);
+
+            MsgDeliveryWorker worker = spy(new MsgDeliveryWorker());
+            worker.start();
+            try {
+                when(sub.getDeliveryWorker()).thenReturn(worker);
+
+                c.processMsg(data, offset, length);
+
+                // InMsgs should be incremented by 1, even if the sub stats don't increase
+                assertEquals(1, c.getStats().getInMsgs());
+                // InBytes should be incremented by length, even if the sub stats don't increase
+                assertEquals(length, c.getStats().getInBytes());
+                // Wait for callback to return
+                latch.await();
+                // Sub max values should have been updated
+                assertEquals(1, sub.getPendingMsgsMax());
+                assertEquals(length, sub.getPendingBytesMax());
+                // Stats of sub should have gone down
+                assertEquals(0, sub.getPendingMsgs());
+                assertEquals(0, sub.getPendingBytes());
+            } finally {
+                worker.shutdown();
+            }
+        }
+    }
+
+    @Test
+    public void testSubscribeWithMsgDeliveryPool() throws Exception {
+        Nats.shutdownMsgDeliveryThreadPool();
+        Nats.createMsgDeliveryThreadPool(1);
+        try {
+            final Options opts = new Options.Builder().useGlobalMsgDelivery(true).build();
+            try (ConnectionImpl c = (ConnectionImpl) spy(newMockedConnection(opts))) {
+                AsyncSubscriptionImpl sub = (AsyncSubscriptionImpl) c.subscribe("foo", mcbMock);
+                assertNotNull(sub);
+                assertNotNull(sub.getDeliveryWorker());
+            }
+        } finally {
+            Nats.shutdownMsgDeliveryThreadPool();
+        }
+    }
+
+    @Test
     public void testProcessSlowConsumer()
             throws Exception {
         try (ConnectionImpl c = (ConnectionImpl) newMockedConnection()) {

--- a/src/test/java/io/nats/client/MessageTest.java
+++ b/src/test/java/io/nats/client/MessageTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2015-2016 Apcera Inc. All rights reserved. This program and the accompanying
+ *  Copyright (c) 2015-2017 Apcera Inc. All rights reserved. This program and the accompanying
  *  materials are made available under the terms of the MIT License (MIT) which accompanies this
  *  distribution, and is available at http://opensource.org/licenses/MIT
  */
@@ -14,10 +14,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import io.nats.client.Parser.MsgArg;
-import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -30,7 +27,7 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 
 @Category(UnitTest.class)
-public class MessageTest {
+public class MessageTest extends BaseUnitTest {
 
     @Mock
     private AsyncSubscriptionImpl subMock;
@@ -38,24 +35,10 @@ public class MessageTest {
     @Rule
     public final ExpectedException thrown = ExpectedException.none();
 
-    @Rule
-    public TestCasePrinterRule pr = new TestCasePrinterRule(System.out);
-
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-    }
-
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-    }
-
     @Before
     public void setUp() throws Exception {
+        super.setUp();
         MockitoAnnotations.initMocks(this);
-    }
-
-    @After
-    public void tearDown() throws Exception {
     }
 
     @Test

--- a/src/test/java/io/nats/client/MsgDeliveryPoolTest.java
+++ b/src/test/java/io/nats/client/MsgDeliveryPoolTest.java
@@ -1,0 +1,101 @@
+/*
+ *  Copyright (c) 2017 Apcera Inc. All rights reserved. This program and the accompanying
+ *  materials are made available under the terms of the MIT License (MIT) which accompanies this
+ *  distribution, and is available at http://opensource.org/licenses/MIT
+ */
+
+package io.nats.client;
+
+import io.nats.client.MsgDeliveryPool;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotEquals;
+import static org.mockito.Mockito.mock;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+
+@Category(UnitTest.class)
+public class MsgDeliveryPoolTest extends BaseUnitTest {
+
+    @Test
+    public void testMsgDeliveryPool() throws Exception {
+        MsgDeliveryPool pool = new MsgDeliveryPool();
+        pool.setSize(5);
+        assertEquals(5, pool.getSize());
+        // We support only expand, so size should not change
+        pool.setSize(2);
+        assertEquals(5, pool.getSize());
+        // expand
+        pool.setSize(7);
+        assertEquals(7, pool.getSize());
+
+        final AtomicInteger received = new AtomicInteger(0);
+        ConnectionImpl nc = mock(ConnectionImpl.class);
+        AsyncSubscriptionImpl sub1 = new AsyncSubscriptionImpl(nc, "foo", null, new MessageHandler() {
+            public void onMessage(Message msg) {
+                received.incrementAndGet();
+            }
+        });
+        // assign worker to sub
+        pool.assignDeliveryWorker(sub1);
+        // check it is assigned to sub
+        MsgDeliveryWorker worker1 = sub1.getDeliveryWorker();
+        assertNotNull(worker1);
+
+        // Make the sub auto-unsubscribe at 2
+        sub1.lock();
+        sub1.max = 2;
+        sub1.unlock();
+        // Post 3 messages
+        for (int i=0; i<3; i++) {
+            final Message msg = new Message("hello".getBytes(), "foo", null, sub1);
+            worker1.lock();
+            worker1.postMsg(msg);
+            worker1.unlock();
+        }
+        // Wait a bit...
+        Thread.sleep(100);
+        // Check that only 2 messages were received.
+        assertEquals(2, received.get());
+
+        received.set(0);
+        AsyncSubscriptionImpl sub2 = new AsyncSubscriptionImpl(nc, "foo", null, new MessageHandler(){
+            public void onMessage(Message msg) {
+                received.incrementAndGet();
+                SubscriptionImpl sub = (SubscriptionImpl) msg.getSubscription();
+                sub.lock();
+                sub.closed = true;
+                sub.unlock();
+            }
+        });
+        // assign worker to sub
+        pool.assignDeliveryWorker(sub2);
+        // check it is assigned to sub
+        MsgDeliveryWorker worker2 = sub2.getDeliveryWorker();
+        assertNotNull(worker2);
+        // Worker should not be same, but that may be a too restrictive test
+        // based on implementation details.
+        assertNotEquals(worker1, worker2);
+        // Send 2 messages, the subscription should have closed after receiving
+        // the first.
+         for (int i=0; i<2; i++) {
+            final Message msg = new Message("hello".getBytes(), "foo", null, sub2);
+            worker2.lock();
+            worker2.postMsg(msg);
+            worker2.unlock();
+        }
+        // Wait a bit...
+        Thread.sleep(100);
+        // Check that only 1 message was received.
+        assertEquals(1, received.get());
+
+        // Shutdown
+        pool.shutdown();
+        assertEquals(0, pool.getSize());
+    }
+}

--- a/src/test/java/io/nats/client/MsgDeliveryPoolTest.java
+++ b/src/test/java/io/nats/client/MsgDeliveryPoolTest.java
@@ -94,21 +94,8 @@ public class MsgDeliveryPoolTest extends BaseUnitTest {
 
     @Test
     public void testMsgDeliveryPool() throws Exception {
-        MsgDeliveryPool pool = new MsgDeliveryPool();
-        // Check zero or negative size is ignored.
-        pool.setSize(-2);
-        assertEquals(0, pool.getSize());
-        pool.setSize(0);
-        assertEquals(0, pool.getSize());
-
-        pool.setSize(5);
+        MsgDeliveryPool pool = new MsgDeliveryPool(5);
         assertEquals(5, pool.getSize());
-        // We support only expand, so size should not change
-        pool.setSize(2);
-        assertEquals(5, pool.getSize());
-        // expand
-        pool.setSize(7);
-        assertEquals(7, pool.getSize());
 
         final AtomicInteger received = new AtomicInteger(0);
         Options opts = Nats.defaultOptions();
@@ -179,13 +166,15 @@ public class MsgDeliveryPoolTest extends BaseUnitTest {
         pool.shutdown();
         assertEquals(0, pool.getSize());
 
-        // Set to size 1
-        pool.setSize(1);
+        // Recreate with size 1
+        pool = new MsgDeliveryPool(1);
 
         // Add 2 subs
         pool.assignDeliveryWorker(sub1);
         pool.assignDeliveryWorker(sub2);
         // Verify they share same thread.
         assertEquals(sub1.getDeliveryWorker(), sub2.getDeliveryWorker());
+        // Shutdown
+        pool.shutdown();
     }
 }

--- a/src/test/java/io/nats/client/MsgDeliveryPoolTest.java
+++ b/src/test/java/io/nats/client/MsgDeliveryPoolTest.java
@@ -35,7 +35,8 @@ public class MsgDeliveryPoolTest extends BaseUnitTest {
         assertEquals(7, pool.getSize());
 
         final AtomicInteger received = new AtomicInteger(0);
-        ConnectionImpl nc = mock(ConnectionImpl.class);
+        Options opts = Nats.defaultOptions();
+        ConnectionImpl nc = new ConnectionImpl(opts);
         AsyncSubscriptionImpl sub1 = new AsyncSubscriptionImpl(nc, "foo", null, new MessageHandler() {
             public void onMessage(Message msg) {
                 received.incrementAndGet();

--- a/src/test/java/io/nats/client/NUIDTest.java
+++ b/src/test/java/io/nats/client/NUIDTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2015-2016 Apcera Inc. All rights reserved. This program and the accompanying
+ *  Copyright (c) 2015-2017 Apcera Inc. All rights reserved. This program and the accompanying
  *  materials are made available under the terms of the MIT License (MIT) which accompanies this
  *  distribution, and is available at http://opensource.org/licenses/MIT
  */
@@ -27,27 +27,7 @@ import java.text.NumberFormat;
 import java.util.Arrays;
 import java.util.Locale;
 
-public class NUIDTest {
-
-    @Rule
-    public TestCasePrinterRule pr = new TestCasePrinterRule(System.out);
-
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-    }
-
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-    }
-
-    @Before
-    public void setUp() throws Exception {
-    }
-
-    @After
-    public void tearDown() throws Exception {
-    }
-
+public class NUIDTest extends BaseUnitTest {
     @Test
     @Category(UnitTest.class)
     public void testDigits() {
@@ -126,7 +106,7 @@ public class NUIDTest {
             nuid.next();
         }
         long elapsedNsec = System.nanoTime() - start;
-        System.out.printf("Average generation time for %d NUIDs was %d ns\n",
+        System.out.printf("Average generation time for %s NUIDs was %f ns\n",
                 NumberFormat.getNumberInstance(Locale.US).format(count),
                 (double) elapsedNsec / count);
 
@@ -143,7 +123,7 @@ public class NUIDTest {
             nuid.next();
         }
         long elapsedNsec = System.nanoTime() - start;
-        System.out.printf("Average generation time for %d global NUIDs was %d ns\n",
+        System.out.printf("Average generation time for %s global NUIDs was %f ns\n",
                 NumberFormat.getNumberInstance(Locale.US).format(count),
                 (double) elapsedNsec / count);
     }

--- a/src/test/java/io/nats/client/NatsBenchTest.java
+++ b/src/test/java/io/nats/client/NatsBenchTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2015-2016 Apcera Inc. All rights reserved. This program and the accompanying
+ *  Copyright (c) 2015-2017 Apcera Inc. All rights reserved. This program and the accompanying
  *  materials are made available under the terms of the MIT License (MIT) which accompanies this
  *  distribution, and is available at http://opensource.org/licenses/MIT
  */
@@ -15,9 +15,7 @@ import static org.junit.Assert.fail;
 import io.nats.examples.NatsBench;
 
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -48,22 +46,11 @@ import java.util.concurrent.atomic.AtomicLong;
 import javax.net.SocketFactory;
 
 @Category(PerfTest.class)
-public class NatsBenchTest {
+public class NatsBenchTest extends BaseUnitTest {
     ExecutorService service;
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
-
-    @Rule
-    public TestCasePrinterRule pr = new TestCasePrinterRule(System.out);
-
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-    }
-
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-    }
 
     /**
      * Per-test-case setup.
@@ -72,6 +59,7 @@ public class NatsBenchTest {
      */
     @Before
     public void setUp() throws Exception {
+        super.setUp();
         service = Executors.newCachedThreadPool(new NatsThreadFactory("natsbench"));
         MockitoAnnotations.initMocks(this);
     }
@@ -83,6 +71,7 @@ public class NatsBenchTest {
      */
     @After
     public void tearDown() throws Exception {
+        super.tearDown();
         service.shutdownNow();
     }
 

--- a/src/test/java/io/nats/client/NatsExceptionTest.java
+++ b/src/test/java/io/nats/client/NatsExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2015-2016 Apcera Inc. All rights reserved. This program and the accompanying
+ *  Copyright (c) 2015-2017 Apcera Inc. All rights reserved. This program and the accompanying
  *  materials are made available under the terms of the MIT License (MIT) which accompanies this
  *  distribution, and is available at http://opensource.org/licenses/MIT
  */
@@ -10,35 +10,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 @Category(UnitTest.class)
-public class NatsExceptionTest {
-    @Rule
-    public TestCasePrinterRule pr = new TestCasePrinterRule(System.out);
-
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-    }
-
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-    }
-
-    @Before
-    public void setUp() throws Exception {
-    }
-
-    @After
-    public void tearDown() throws Exception {
-    }
-
+public class NatsExceptionTest extends BaseUnitTest {
     @Test
     public void testNatsEx() {
         NATSException nex = new NATSException();

--- a/src/test/java/io/nats/client/NatsTest.java
+++ b/src/test/java/io/nats/client/NatsTest.java
@@ -60,20 +60,22 @@ public class NatsTest extends BaseUnitTest {
 
 
     @Test
-    public void testMsgDeliveryThreadPoolSize() {
+    public void testMsgDeliveryThreadPool() {
         boolean ok = false;
-        try { Nats.setMsgDeliveryThreadPoolSize(-1); } catch (IllegalArgumentException e) { ok = true; }
+        try { Nats.createMsgDeliveryThreadPool(-1); } catch (IllegalArgumentException e) { ok = true; }
         assertTrue(ok);
         assertEquals(0, Nats.getMsgDeliveryThreadPoolSize());
 
-        Nats.setMsgDeliveryThreadPoolSize(3);
+        Nats.createMsgDeliveryThreadPool(3);
         int ps = Nats.getMsgDeliveryThreadPoolSize();
         assertEquals(3, ps);
 
-        // Since we don't support reducing size of the pool, size should remain at 3.
-        Nats.setMsgDeliveryThreadPoolSize(1);
-        ps = Nats.getMsgDeliveryThreadPoolSize();
-        assertEquals(3, ps);
+        // Trying to create again should fail
+        ok = false;
+        try { Nats.createMsgDeliveryThreadPool(5); } catch (IllegalStateException e) { ok = true; }
+        assertTrue(ok);
+        // Should still be of size 3.
+        assertEquals(3, Nats.getMsgDeliveryThreadPoolSize());
 
         // However, on shutdown, we want to clear the pool.
         Nats.shutdownMsgDeliveryThreadPool();
@@ -81,7 +83,7 @@ public class NatsTest extends BaseUnitTest {
         assertEquals(0, ps);
 
         // Restart pool
-        Nats.setMsgDeliveryThreadPoolSize(2);
+        Nats.createMsgDeliveryThreadPool(2);
         ps = Nats.getMsgDeliveryThreadPoolSize();
         assertEquals(2, ps);
 

--- a/src/test/java/io/nats/client/NatsTest.java
+++ b/src/test/java/io/nats/client/NatsTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2015-2016 Apcera Inc. All rights reserved. This program and the accompanying materials are made available under the terms of the MIT License (MIT) which accompanies this distribution, and is available at http://opensource.org/licenses/MIT
+ *  Copyright (c) 2015-2017 Apcera Inc. All rights reserved. This program and the accompanying materials are made available under the terms of the MIT License (MIT) which accompanies this distribution, and is available at http://opensource.org/licenses/MIT
  */
 
 package io.nats.client;
@@ -9,38 +9,20 @@ import static org.junit.Assert.*;
 
 import java.net.URI;
 import java.util.List;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import org.junit.experimental.categories.Category;
+
+@Category(UnitTest.class)
 /**
  * Created by larry on 11/15/16.
  */
-public class NatsTest {
+public class NatsTest extends BaseUnitTest {
 
     @Rule
     public final ExpectedException thrown = ExpectedException.none();
-
-    @Rule
-    public TestCasePrinterRule pr = new TestCasePrinterRule(System.out);
-
-    @Before
-    public void setUp() throws Exception {}
-
-    @After
-    public void tearDown() throws Exception {}
-
-//    @Test
-//    public void connect() throws Exception {
-//        Nats.connect();
-//    }
-
-//    @Test
-//    public void connectUrl() throws Exception {
-//        Nats.connect()
-//    }
 
     @Test
     public void connectUrlOptions() throws Exception {
@@ -76,4 +58,37 @@ public class NatsTest {
         assertEquals("nats://anotherhost:2222", uriList.get(1).toString());
     }
 
+
+    @Test
+    public void testMsgDeliveryThreadPoolSize() {
+        boolean ok = false;
+        try { Nats.setMsgDeliveryThreadPoolSize(-1); } catch (IllegalArgumentException e) { ok = true; }
+        assertTrue(ok);
+        assertEquals(0, Nats.getMsgDeliveryThreadPoolSize());
+
+        Nats.setMsgDeliveryThreadPoolSize(3);
+        int ps = Nats.getMsgDeliveryThreadPoolSize();
+        assertEquals(3, ps);
+
+        // Since we don't support reducing size of the pool, size should remain at 3.
+        Nats.setMsgDeliveryThreadPoolSize(1);
+        ps = Nats.getMsgDeliveryThreadPoolSize();
+        assertEquals(3, ps);
+
+        // However, on shutdown, we want to clear the pool.
+        Nats.shutdownMsgDeliveryThreadPool();
+        ps = Nats.getMsgDeliveryThreadPoolSize();
+        assertEquals(0, ps);
+
+        // Restart pool
+        Nats.setMsgDeliveryThreadPoolSize(2);
+        ps = Nats.getMsgDeliveryThreadPoolSize();
+        assertEquals(2, ps);
+
+        // Shutdown
+        Nats.shutdownMsgDeliveryThreadPool();
+        ps = Nats.getMsgDeliveryThreadPoolSize();
+        assertEquals(0, ps);
+        assertNull(Nats.getMsgDeliveryThreadPool());
+    }
 }

--- a/src/test/java/io/nats/client/NatsThreadTest.java
+++ b/src/test/java/io/nats/client/NatsThreadTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2015-2016 Apcera Inc. All rights reserved. This program and the accompanying
+ *  Copyright (c) 2015-2017 Apcera Inc. All rights reserved. This program and the accompanying
  *  materials are made available under the terms of the MIT License (MIT) which accompanies this
  *  distribution, and is available at http://opensource.org/licenses/MIT
  */
@@ -7,41 +7,16 @@
 package io.nats.client;
 
 import static io.nats.client.UnitTestUtilities.sleep;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
 @Category(UnitTest.class)
-public class NatsThreadTest implements Runnable {
-    @Rule
-    public TestCasePrinterRule pr = new TestCasePrinterRule(System.out);
-
+public class NatsThreadTest extends BaseUnitTest implements Runnable {
     private static final int NUM_THREADS = 5;
-
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-    }
-
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-    }
-
-    @Before
-    public void setUp() throws Exception {
-    }
-
-    @After
-    public void tearDown() throws Exception {
-    }
 
     @Test
     public void testRun() {

--- a/src/test/java/io/nats/client/OptionsTest.java
+++ b/src/test/java/io/nats/client/OptionsTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2015-2016 Apcera Inc. All rights reserved. This program and the accompanying
+ *  Copyright (c) 2015-2017 Apcera Inc. All rights reserved. This program and the accompanying
  *  materials are made available under the terms of the MIT License (MIT) which accompanies this
  *  distribution, and is available at http://opensource.org/licenses/MIT
  */
@@ -27,16 +27,12 @@ import static io.nats.client.Nats.PROP_TLS_DEBUG;
 import static io.nats.client.Nats.PROP_URL;
 import static io.nats.client.Nats.PROP_USERNAME;
 import static io.nats.client.Nats.PROP_VERBOSE;
+import static io.nats.client.Nats.PROP_USE_GLOBAL_MSG_DELIVERY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import java.util.concurrent.TimeUnit;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -48,26 +44,7 @@ import java.util.Properties;
 import javax.net.ssl.SSLContext;
 
 @Category(UnitTest.class)
-public class OptionsTest {
-    @Rule
-    public TestCasePrinterRule pr = new TestCasePrinterRule(System.out);
-
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-    }
-
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-    }
-
-    @Before
-    public void setUp() throws Exception {
-    }
-
-    @After
-    public void tearDown() throws Exception {
-    }
-
+public class OptionsTest extends BaseUnitTest {
     private static final String url = "nats://foobar:4122";
     static final String hostname = "foobar2";
     static final int port = 2323;
@@ -88,6 +65,7 @@ public class OptionsTest {
     private static final int timeout = 2000;
     private static final int pingInterval = 5000;
     private static final int maxPings = 4;
+    private static final boolean useGlobalMsgDelivery = true;
     static final Boolean tlsDebug = true;
 
     @Test
@@ -122,6 +100,7 @@ public class OptionsTest {
         props.setProperty(PROP_CLOSED_CB, ccb.getClass().getName());
         props.setProperty(PROP_DISCONNECTED_CB, dcb.getClass().getName());
         props.setProperty(PROP_RECONNECTED_CB, rcb.getClass().getName());
+        props.setProperty(PROP_USE_GLOBAL_MSG_DELIVERY, Boolean.toString(useGlobalMsgDelivery));
 
         Options opts = new Options.Builder(props).build();
 
@@ -159,12 +138,7 @@ public class OptionsTest {
         String token = "alkjsdf09234ipoiasfasdf";
         List<URI> servers = Arrays.asList(URI.create("nats://foobar:1222"), URI.create
                 ("nats://localhost:2222"));
-        boolean noRandomize = true;
         String connectionName = "myConnection";
-        boolean verbose = true;
-        boolean pedantic = true;
-        boolean secure = true;
-        boolean allowReconnect = false;
         int maxReconnect = 20;
         int reconnectBufSize = 12345678;
         long reconnectWait = 742;
@@ -172,15 +146,11 @@ public class OptionsTest {
         long pingInterval = 200000;
         int maxPingsOut = 7;
         SSLContext sslContext = SSLContext.getInstance(Nats.DEFAULT_SSL_PROTOCOL);
-        boolean tlsDebug = true;
         TcpConnectionFactory factory = UnitTestUtilities.newMockedTcpConnectionFactory();
         DisconnectedCallback disconnectedCb = mock(DisconnectedCallback.class);
         ClosedCallback closedCb = mock(ClosedCallback.class);
         ReconnectedCallback reconnectedCb = mock(ReconnectedCallback.class);
         ExceptionHandler asyncErrorCb = mock(ExceptionHandler.class);
-
-        String host = "myhost";
-        int port = 2122;
 
         Options expected = new Options.Builder()
                 .userInfo(username, password)
@@ -204,6 +174,7 @@ public class OptionsTest {
                 .closedCb(closedCb)
                 .reconnectedCb(reconnectedCb)
                 .errorCb(asyncErrorCb)
+                .useGlobalMsgDelivery(true)
                 .build();
 
         expected.url = url;
@@ -242,5 +213,6 @@ public class OptionsTest {
     @Test
     public void testHashcode() {
         int hash = new Options.Builder().build().hashCode();
+        assertTrue(hash != 0);
     }
 }

--- a/src/test/java/io/nats/client/ParserPerfTest.java
+++ b/src/test/java/io/nats/client/ParserPerfTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2015-2016 Apcera Inc. All rights reserved. This program and the accompanying
+ *  Copyright (c) 2015-2017 Apcera Inc. All rights reserved. This program and the accompanying
  *  materials are made available under the terms of the MIT License (MIT) which accompanies this
  *  distribution, and is available at http://opensource.org/licenses/MIT
  */
@@ -7,39 +7,13 @@
 package io.nats.client;
 
 import static io.nats.client.UnitTestUtilities.newMockedConnection;
-import static org.junit.Assert.fail;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.text.ParseException;
 import java.util.concurrent.TimeUnit;
 
-public class ParserPerfTest {
-    @Rule
-    public TestCasePrinterRule pr = new TestCasePrinterRule(System.out);
-
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-    }
-
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-    }
-
-    @Before
-    public void setUp() throws Exception {
-    }
-
-    @After
-    public void tearDown() throws Exception {
-    }
-
+public class ParserPerfTest extends BaseUnitTest {
     @Test
     public void test() throws Exception {
         try (ConnectionImpl conn = (ConnectionImpl) newMockedConnection()) {

--- a/src/test/java/io/nats/client/ParserTest.java
+++ b/src/test/java/io/nats/client/ParserTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2015-2016 Apcera Inc. All rights reserved. This program and the accompanying
+ *  Copyright (c) 2015-2017 Apcera Inc. All rights reserved. This program and the accompanying
  *  materials are made available under the terms of the MIT License (MIT) which accompanies this
  *  distribution, and is available at http://opensource.org/licenses/MIT
  */
@@ -40,29 +40,15 @@ import org.junit.rules.ExpectedException;
 import org.mockito.MockitoAnnotations;
 
 @Category(UnitTest.class)
-public class ParserTest {
+public class ParserTest extends BaseUnitTest {
 
     @Rule
     public final ExpectedException thrown = ExpectedException.none();
 
-    @Rule
-    public TestCasePrinterRule pr = new TestCasePrinterRule(System.out);
-
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-    }
-
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-    }
-
     @Before
     public void setUp() throws Exception {
+        super.setUp();
         MockitoAnnotations.initMocks(this);
-    }
-
-    @After
-    public void tearDown() throws Exception {
     }
 
     private static final String[] testServers = {"nats://localhost:1222", "nats://localhost:1223",

--- a/src/test/java/io/nats/client/PublisherTest.java
+++ b/src/test/java/io/nats/client/PublisherTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2015-2016 Apcera Inc. All rights reserved. This program and the accompanying
+ *  Copyright (c) 2015-2017 Apcera Inc. All rights reserved. This program and the accompanying
  *  materials are made available under the terms of the MIT License (MIT) which accompanies this
  *  distribution, and is available at http://opensource.org/licenses/MIT
  */
@@ -12,10 +12,6 @@ import static org.junit.Assert.assertTrue;
 
 import io.nats.examples.Publisher;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -27,29 +23,10 @@ import java.util.Collections;
 import java.util.List;
 
 @Category(IntegrationTest.class)
-public class PublisherTest {
+public class PublisherTest extends BaseUnitTest {
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
-
-    @Rule
-    public TestCasePrinterRule pr = new TestCasePrinterRule(System.out);
-
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-    }
-
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-    }
-
-    @Before
-    public void setUp() throws Exception {
-    }
-
-    @After
-    public void tearDown() throws Exception {
-    }
 
     @Test
     public void testPublisherStringArray() throws Exception {

--- a/src/test/java/io/nats/client/ReplierTest.java
+++ b/src/test/java/io/nats/client/ReplierTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2015-2016 Apcera Inc. All rights reserved. This program and the accompanying
+ *  Copyright (c) 2015-2017 Apcera Inc. All rights reserved. This program and the accompanying
  *  materials are made available under the terms of the MIT License (MIT) which accompanies this
  *  distribution, and is available at http://opensource.org/licenses/MIT
  */
@@ -15,10 +15,6 @@ import static org.junit.Assert.fail;
 import io.nats.examples.Replier;
 import io.nats.examples.Requestor;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -33,31 +29,12 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 @Category(IntegrationTest.class)
-public class ReplierTest {
+public class ReplierTest extends BaseUnitTest {
 
     private final ExecutorService service = Executors.newCachedThreadPool();
 
     @Rule
     public final ExpectedException thrown = ExpectedException.none();
-
-    @Rule
-    public TestCasePrinterRule pr = new TestCasePrinterRule(System.out);
-
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-    }
-
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-    }
-
-    @Before
-    public void setUp() throws Exception {
-    }
-
-    @After
-    public void tearDown() throws Exception {
-    }
 
     @Test
     public void testReplierStringArray() throws Exception {

--- a/src/test/java/io/nats/client/RequestorTest.java
+++ b/src/test/java/io/nats/client/RequestorTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2015-2016 Apcera Inc. All rights reserved. This program and the accompanying
+ *  Copyright (c) 2015-2017 Apcera Inc. All rights reserved. This program and the accompanying
  *  materials are made available under the terms of the MIT License (MIT) which accompanies this
  *  distribution, and is available at http://opensource.org/licenses/MIT
  */
@@ -17,10 +17,6 @@ import io.nats.examples.Requestor;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -32,31 +28,12 @@ import java.util.Collections;
 import java.util.List;
 
 @Category(IntegrationTest.class)
-public class RequestorTest {
+public class RequestorTest extends BaseUnitTest {
 
     final ExecutorService service = Executors.newCachedThreadPool();
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
-
-    @Rule
-    public TestCasePrinterRule pr = new TestCasePrinterRule(System.out);
-
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-    }
-
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-    }
-
-    @Before
-    public void setUp() throws Exception {
-    }
-
-    @After
-    public void tearDown() throws Exception {
-    }
 
     @Test
     public void testRequestorStringArray() throws Exception {

--- a/src/test/java/io/nats/client/ServerInfoTest.java
+++ b/src/test/java/io/nats/client/ServerInfoTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2015-2016 Apcera Inc. All rights reserved. This program and the accompanying
+ *  Copyright (c) 2015-2017 Apcera Inc. All rights reserved. This program and the accompanying
  *  materials are made available under the terms of the MIT License (MIT) which accompanies this
  *  distribution, and is available at http://opensource.org/licenses/MIT
  */
@@ -12,20 +12,12 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 
 @Category(UnitTest.class)
-public class ServerInfoTest {
-
-    @Rule
-    public TestCasePrinterRule pr = new TestCasePrinterRule(System.out);
+public class ServerInfoTest extends BaseUnitTest {
 
     private static final String testString =
             "INFO {\"server_id\":\"s76hOxUCzhR2ngkcVYSPPV\",\"version\":\"0.9.4\","
@@ -39,22 +31,6 @@ public class ServerInfoTest {
                     + "\"auth_required\":true,\"ssl_required\":true,\"tls_required\":true,"
                     + "\"tls_verify\":false,\"max_payload\":1048576}\r\n";
     private static final ServerInfo testInstance = ServerInfo.createFromWire(testString);
-
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-    }
-
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-    }
-
-    @Before
-    public void setUp() throws Exception {
-    }
-
-    @After
-    public void tearDown() throws Exception {
-    }
 
     /**
      * Test method for {@link io.nats.client.ServerInfo#ServerInfo(io.nats.client.ServerInfo)}.

--- a/src/test/java/io/nats/client/StatisticsTest.java
+++ b/src/test/java/io/nats/client/StatisticsTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2015-2016 Apcera Inc. All rights reserved. This program and the accompanying
+ *  Copyright (c) 2015-2017 Apcera Inc. All rights reserved. This program and the accompanying
  *  materials are made available under the terms of the MIT License (MIT) which accompanies this
  *  distribution, and is available at http://opensource.org/licenses/MIT
  */
@@ -10,10 +10,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -21,29 +18,15 @@ import org.junit.rules.ExpectedException;
 import org.mockito.MockitoAnnotations;
 
 @Category(UnitTest.class)
-public class StatisticsTest {
+public class StatisticsTest extends BaseUnitTest {
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
-    @Rule
-    public TestCasePrinterRule pr = new TestCasePrinterRule(System.out);
-
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-    }
-
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-    }
-
     @Before
     public void setUp() throws Exception {
+        super.setUp();
         MockitoAnnotations.initMocks(this);
-    }
-
-    @After
-    public void tearDown() throws Exception {
     }
 
     private Statistics createDummyStats() {

--- a/src/test/java/io/nats/client/SubscriberTest.java
+++ b/src/test/java/io/nats/client/SubscriberTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2015-2016 Apcera Inc. All rights reserved. This program and the accompanying
+ *  Copyright (c) 2015-2017 Apcera Inc. All rights reserved. This program and the accompanying
  *  materials are made available under the terms of the MIT License (MIT) which accompanies this
  *  distribution, and is available at http://opensource.org/licenses/MIT
  */
@@ -15,10 +15,6 @@ import static org.junit.Assert.fail;
 import io.nats.examples.Publisher;
 import io.nats.examples.Subscriber;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -33,31 +29,12 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 @Category(IntegrationTest.class)
-public class SubscriberTest {
+public class SubscriberTest extends BaseUnitTest  {
 
     final ExecutorService service = Executors.newCachedThreadPool();
 
     @Rule
     public final ExpectedException thrown = ExpectedException.none();
-
-    @Rule
-    public TestCasePrinterRule pr = new TestCasePrinterRule(System.out);
-
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-    }
-
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-    }
-
-    @Before
-    public void setUp() throws Exception {
-    }
-
-    @After
-    public void tearDown() throws Exception {
-    }
 
     @Test
     public void testSubscriberStringArray() throws Exception {

--- a/src/test/java/io/nats/client/SubscriptionImplTest.java
+++ b/src/test/java/io/nats/client/SubscriptionImplTest.java
@@ -357,6 +357,7 @@ public class SubscriptionImplTest extends BaseUnitTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testGetQueuedMessageCount() {
         String subj = "foo";
         String queue = "bar";

--- a/src/test/java/io/nats/client/SubscriptionImplTest.java
+++ b/src/test/java/io/nats/client/SubscriptionImplTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2015-2016 Apcera Inc. All rights reserved. This program and the accompanying
+ *  Copyright (c) 2015-2017 Apcera Inc. All rights reserved. This program and the accompanying
  *  materials are made available under the terms of the MIT License (MIT) which accompanies this
  *  distribution, and is available at http://opensource.org/licenses/MIT
  */
@@ -20,10 +20,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -35,13 +32,10 @@ import java.io.IOException;
 import java.util.concurrent.BlockingQueue;
 
 @Category(UnitTest.class)
-public class SubscriptionImplTest {
+public class SubscriptionImplTest extends BaseUnitTest {
 
     @Rule
     public final ExpectedException thrown = ExpectedException.none();
-
-    @Rule
-    public TestCasePrinterRule pr = new TestCasePrinterRule(System.out);
 
     @Mock
     private ConnectionImpl connMock;
@@ -52,21 +46,10 @@ public class SubscriptionImplTest {
     @Mock
     private MessageHandler mcbMock;
 
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-    }
-
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-    }
-
     @Before
     public void setUp() throws Exception {
+        super.setUp();
         MockitoAnnotations.initMocks(this);
-    }
-
-    @After
-    public void tearDown() throws Exception {
     }
 
     @Test
@@ -348,11 +331,11 @@ public class SubscriptionImplTest {
         when(mchMock.size()).thenReturn(count);
         try (SyncSubscriptionImpl sub = new SyncSubscriptionImpl(connMock, subj, queue)) {
             sub.pMsgs = count;
-            assertEquals(count, sub.getQueuedMessageCount());
+            assertEquals(count, sub.getPendingMsgs());
         }
 
         try (SyncSubscriptionImpl sub = new SyncSubscriptionImpl(null, subj, queue)) {
-            sub.getQueuedMessageCount();
+            sub.getPendingMsgs();
         }
     }
 

--- a/src/test/java/io/nats/client/SyncSubscriptionImplTest.java
+++ b/src/test/java/io/nats/client/SyncSubscriptionImplTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2015-2016 Apcera Inc. All rights reserved. This program and the accompanying
+ *  Copyright (c) 2015-2017 Apcera Inc. All rights reserved. This program and the accompanying
  *  materials are made available under the terms of the MIT License (MIT) which accompanies this
  *  distribution, and is available at http://opensource.org/licenses/MIT
  */
@@ -20,9 +20,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -38,13 +36,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 
 @Category(UnitTest.class)
-public class SyncSubscriptionImplTest {
+public class SyncSubscriptionImplTest extends BaseUnitTest {
 
     @Rule
     public final ExpectedException thrown = ExpectedException.none();
-
-    @Rule
-    public TestCasePrinterRule pr = new TestCasePrinterRule(System.out);
 
     @Mock
     private ConnectionImpl connMock;
@@ -57,14 +52,6 @@ public class SyncSubscriptionImplTest {
 
     private ExecutorService exec;
 
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-    }
-
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-    }
-
     /**
      * Per-test-case setup.
      *
@@ -72,6 +59,7 @@ public class SyncSubscriptionImplTest {
      */
     @Before
     public void setUp() throws Exception {
+        super.setUp();
         exec = Executors.newCachedThreadPool();
         MockitoAnnotations.initMocks(this);
     }
@@ -83,6 +71,7 @@ public class SyncSubscriptionImplTest {
      */
     @After
     public void tearDown() throws Exception {
+        super.tearDown();
         exec.shutdownNow();
     }
 

--- a/src/test/java/io/nats/client/TcpConnectionTest.java
+++ b/src/test/java/io/nats/client/TcpConnectionTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2015-2016 Apcera Inc. All rights reserved. This program and the accompanying
+ *  Copyright (c) 2015-2017 Apcera Inc. All rights reserved. This program and the accompanying
  *  materials are made available under the terms of the MIT License (MIT) which accompanies this
  *  distribution, and is available at http://opensource.org/licenses/MIT
  */
@@ -18,10 +18,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 
-import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -41,13 +38,10 @@ import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 
 @Category(UnitTest.class)
-public class TcpConnectionTest {
+public class TcpConnectionTest extends BaseUnitTest {
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
-
-    @Rule
-    public TestCasePrinterRule pr = new TestCasePrinterRule(System.out);
 
     @Mock
     private InputStream readStreamMock;
@@ -55,21 +49,10 @@ public class TcpConnectionTest {
     @Mock
     private OutputStream writeStreamMock;
 
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-    }
-
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-    }
-
     @Before
     public void setUp() throws Exception {
+        super.setUp();
         MockitoAnnotations.initMocks(this);
-    }
-
-    @After
-    public void tearDown() throws Exception {
     }
 
     @SuppressWarnings("resource")


### PR DESCRIPTION
This PR adds the ability to set a library level thread pool
responsible for dispatching asynchronous subscriptions' messages.
All messages from a given subscription will be delivered in
the order they arrived.

This also maintains the contract that a subscription reaching its
auto-unsubscribe max or being unsubscribed (or the connection
being closed) in the message callback prevents subsequent delivery
of messages to that subscription (even if they were already received
by the connection).

A connection option allows the user to force the subscription
to use its own thread to dispatch its message even if the
library pool has been set.

For the new code and fixing the current behavior of `waitForMsgs` that
should catch any throwable issued by the user callback and continue 
to work.

Resolves #114
