### PR TITLE
[FIXED] NPE in io.nats.client.Message#getSubject

### DIFF
--- a/src/main/java/io/nats/client/Message.java
+++ b/src/main/java/io/nats/client/Message.java
@@ -102,7 +102,7 @@ public class Message {
      * @return the message subject
      */
     public String getSubject() {
-        if (subjectString == null) {
+        if (subjectString == null && subjectBytes != null) {
             subjectString = new String(subjectBytes, 0, subjectBytes.length);
         }
         return subjectString;

--- a/src/test/java/io/nats/client/MessageTest.java
+++ b/src/test/java/io/nats/client/MessageTest.java
@@ -239,4 +239,12 @@ public class MessageTest extends BaseUnitTest {
                 + "<this is a really long message th60 more bytes>}", msg.toString());
     }
 
+    @Test
+    public void testDataOnlyToString() {
+        byte[] data = "hello".getBytes();
+        Message msg = new Message();
+        msg.setData(data);
+        assertEquals("{Subject=null;Reply=null;Payload=<hello>}", msg.toString());
+    }
+
 }


### PR DESCRIPTION
Adding null check to `io.nats.client.Message#getSubject` to match behavior with `getReplyTo` and make `toString` work, fixing #146 