### PR TITLE
handle IOExceptions while writing resubscriptions (and pending data) …

### DIFF
--- a/src/it/java/io/nats/client/ITSubscriptionTest.java
+++ b/src/it/java/io/nats/client/ITSubscriptionTest.java
@@ -703,13 +703,18 @@ public class ITSubscriptionTest extends ITBaseTest {
                         public void onMessage(Message msg) {
                             // System.err.println("Responder");
                             String responseInbox = c.newInbox();
-                            c.subscribe(responseInbox, new MessageHandler() {
-                                public void onMessage(Message msg) {
-                                    // System.err.println("Internal subscriber.");
-                                    sleep(100);
-                                    latch.countDown();
-                                }
-                            });
+                            try {
+                                c.subscribe(responseInbox, new MessageHandler() {
+                                    public void onMessage(Message msg) {
+                                        // System.err.println("Internal subscriber.");
+                                        sleep(100);
+                                        latch.countDown();
+                                    }
+                                });
+                            } catch(IOException e) {
+                                e.printStackTrace();
+                            }
+
                             // System.err.println("starter subscribed");
                             sleep(100);
                             try {

--- a/src/main/java/io/nats/client/AbstractConnection.java
+++ b/src/main/java/io/nats/client/AbstractConnection.java
@@ -23,8 +23,9 @@ public interface AbstractConnection extends AutoCloseable {
      * @throws IllegalArgumentException if the subject name contains illegal characters.
      * @throws NullPointerException     if the subject name is null
      * @throws IllegalStateException    if the connection is closed
+     * @throws IOException
      */
-    SyncSubscription subscribe(String subject);
+    SyncSubscription subscribe(String subject) throws IOException;
 
     /**
      * Creates a {@link SyncSubscription} with interest in a given subject. All subscribers with the
@@ -37,8 +38,9 @@ public interface AbstractConnection extends AutoCloseable {
      * @throws IllegalArgumentException if the subject (or queue) name contains illegal characters.
      * @throws NullPointerException     if the subject name is null
      * @throws IllegalStateException    if the connection is closed
+     * @throws IOException
      */
-    SyncSubscription subscribe(String subject, String queue);
+    SyncSubscription subscribe(String subject, String queue) throws IOException;
 
     /**
      * Creates a {@code AsyncSubscription} with interest in a given subject, assign the callback,
@@ -51,8 +53,9 @@ public interface AbstractConnection extends AutoCloseable {
      * @throws IllegalArgumentException if the subject (or queue) name contains illegal characters.
      * @throws NullPointerException     if the subject name is null
      * @throws IllegalStateException    if the connection is closed
+     * @throws IOException
      */
-    AsyncSubscription subscribe(String subject, MessageHandler cb);
+    AsyncSubscription subscribe(String subject, MessageHandler cb) throws IOException;
 
     /**
      * Creates an asynchronous queue subscriber on a given subject of interest. All subscribers with
@@ -64,8 +67,9 @@ public interface AbstractConnection extends AutoCloseable {
      * @param cb      a {@code MessageHandler} object used to process messages received by the
      *                {@code Subscription}
      * @return {@code Subscription}
+     * @throws IOException
      */
-    AsyncSubscription subscribe(String subject, String queue, MessageHandler cb);
+    AsyncSubscription subscribe(String subject, String queue, MessageHandler cb) throws IOException;
 
     /**
      * Creates a {@code AsyncSubscription} with interest in a given subject, assign the callback,
@@ -78,9 +82,10 @@ public interface AbstractConnection extends AutoCloseable {
      * @throws IllegalArgumentException if the subject (or queue) name contains illegal characters.
      * @throws NullPointerException     if the subject name is null
      * @throws IllegalStateException    if the connection is closed
+     * @throws IOException
      * @deprecated As of release 0.6, use {@link #subscribe(String, MessageHandler)} instead
      */
-    AsyncSubscription subscribeAsync(String subject, MessageHandler cb);
+    AsyncSubscription subscribeAsync(String subject, MessageHandler cb) throws IOException;
 
     /**
      * Create an {@code AsyncSubscription} with interest in a given subject, assign the message
@@ -93,9 +98,10 @@ public interface AbstractConnection extends AutoCloseable {
      * @throws IllegalArgumentException if the subject (or queue) name contains illegal characters.
      * @throws NullPointerException     if the subject name is null
      * @throws IllegalStateException    if the connection is closed
+     * @throws IOException
      * @deprecated As of release 0.6, use {@link #subscribe(String, String, MessageHandler)} instead
      */
-    AsyncSubscription subscribeAsync(String subject, String queue, MessageHandler cb);
+    AsyncSubscription subscribeAsync(String subject, String queue, MessageHandler cb) throws IOException;
 
     /**
      * Creates a synchronous queue subscriber on a given subject of interest. All subscribers with
@@ -109,8 +115,9 @@ public interface AbstractConnection extends AutoCloseable {
      * @throws IllegalArgumentException if the subject (or queue) name contains illegal characters.
      * @throws NullPointerException     if the subject name is null
      * @throws IllegalStateException    if the connection is closed
+     * @throws IOException
      */
-    SyncSubscription subscribeSync(String subject, String queue);
+    SyncSubscription subscribeSync(String subject, String queue) throws IOException;
 
     /**
      * Creates a {@link SyncSubscription} with interest in a given subject. In order to receive
@@ -121,8 +128,9 @@ public interface AbstractConnection extends AutoCloseable {
      * @throws IllegalArgumentException if the subject name contains illegal characters.
      * @throws NullPointerException     if the subject name is null
      * @throws IllegalStateException    if the connection is closed
+     * @throws IOException
      */
-    SyncSubscription subscribeSync(String subject);
+    SyncSubscription subscribeSync(String subject) throws IOException;
 
     /**
      * Creates a new, uniquely named inbox with the prefix '_INBOX.'

--- a/src/test/java/io/nats/client/ConnectionImplTest.java
+++ b/src/test/java/io/nats/client/ConnectionImplTest.java
@@ -259,6 +259,7 @@ public class ConnectionImplTest extends BaseUnitTest {
 
     @Test
     public void testFlushReconnectPendingItems() throws Exception {
+        thrown.expect(IOException.class);
         try (ConnectionImpl c = (ConnectionImpl) newMockedConnection()) {
             byte[] pingProtoBytes = ConnectionImpl.PING_PROTO.getBytes();
             int pingProtoBytesLen = pingProtoBytes.length;
@@ -1913,6 +1914,7 @@ public class ConnectionImplTest extends BaseUnitTest {
 
     @Test
     public void testSendSubscriptionMessage() throws Exception {
+        thrown.expect(IOException.class);
         try (ConnectionImpl c = (ConnectionImpl) newMockedConnection()) {
             SubscriptionImpl mockSub = mock(SubscriptionImpl.class);
             String subject = doReturn("foo").when(mockSub).getSubject();


### PR DESCRIPTION
IOExceptions thrown as a result of writing to the OutputStream during a reconnect, whilst trying to write subscription (and pending) commands should not be silently ignored.  This could lead to the scenario where the library believes it has successfully recovered a connection, but where some subscriptions have not been re-established.

This scenario may also be especially likely, given that the reconnection code may run where there are networking issues/partitions .  At this time, conceivably, a backlog of pending RPC-like requests (i.e., publishes that require a response via a one-shot inbox) may have accumulated, leading to an excess of subscriptions to re-establish.