### PR TITLE
Do not call exception handler on IOException during connection closing/draining

### DIFF
--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -1379,6 +1379,15 @@ class NatsConnection implements Connection {
         }
     }
 
+    boolean isClosingOrDraining() {
+        statusLock.lock();
+        try {
+            return this.closing || this.isDraining();
+        } finally {
+            statusLock.unlock();
+        }
+    }
+
     void waitForDisconnectOrClose(Duration timeout) throws InterruptedException {
         waitFor(timeout, (Void) -> {
             return this.isDisconnecting() && !this.isClosed();

--- a/src/main/java/io/nats/client/impl/NatsConnectionReader.java
+++ b/src/main/java/io/nats/client/impl/NatsConnectionReader.java
@@ -143,7 +143,10 @@ class NatsConnectionReader implements Runnable {
                 }
             }
         } catch (IOException io) {
-            this.connection.handleCommunicationIssue(io);
+            // SocketException is thrown when connection is closing or draining, no need to handle
+            if (!this.connection.isClosingOrDraining()) {
+                this.connection.handleCommunicationIssue(io);
+            }
         } catch (CancellationException | ExecutionException | InterruptedException ex) {
             // Exit
         } finally {
@@ -352,7 +355,7 @@ class NatsConnectionReader implements Runnable {
             } else if (chars[0] == '-' && 
                         (chars[1] == 'E' || chars[1] == 'e') &&
                         (chars[2] == 'R' || chars[2] == 'r') && 
-                        (chars[3] == 'R' || chars[3] == 'R')) {
+                        (chars[3] == 'R' || chars[3] == 'r')) {
                 return NatsConnection.OP_ERR;
             } else if ((chars[0] == 'I' || chars[0] == 'i') && 
                         (chars[1] == 'N' || chars[1] == 'n') && 

--- a/src/test/java/io/nats/client/impl/DrainTests.java
+++ b/src/test/java/io/nats/client/impl/DrainTests.java
@@ -714,7 +714,6 @@ public class DrainTests {
 
             assertFalse(tracker.get(3, TimeUnit.SECONDS));
             assertFalse(((NatsConnection) subCon).isDrained());
-            assertTrue(handler.getExceptionCount() > 0);
             assertTrue(Connection.Status.CLOSED == subCon.getStatus());
         }
     }


### PR DESCRIPTION
Fixes https://github.com/nats-io/java-nats/issues/217.

Confirmed exceptionOccurred is not triggered with the same example code listed in 217. 