### PR TITLE
2.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [CHANGED] - no longer call exception handler for "ignored" communication exceptions during close/drain after close occurs
 * [ADDED] - #209 - support for comma separated urls in connect() or server()
 * [FIXED] - #206 - incorrect error message when reconnect buffer is overrun
+* [CHANGED] - #214 - moved to an executor instead of 1-off threads
 
 ## Version 2.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 
 # Change Log
 
+## Version 2.4.2
+
+* [FIXED] - #217 - added check to "ignore" exceptions from reader during drain
+* [CHANGED] - no longer call exception handler for "ignored" communication exceptions during close/drain after close occurs
+
 ## Version 2.4.1
 
 * [FIXED] - #199 - turns out we had to hard code the manifest to remove the private package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [FIXED] - #220 - an icky timing issue that could delay messages
 * [CHANGED] - added larger TCP defaults to improve network performance
 * [ADDED] - public method to create an inbox subject using the prefix from options
+* [FIXED] - #203 & #204 - Fixed a thread/timing issue with writer and cleaning pong queues
 
 ## Version 2.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 * [FIXED] - #217 - added check to "ignore" exceptions from reader during drain
 * [CHANGED] - no longer call exception handler for "ignored" communication exceptions during close/drain after close occurs
+* [ADDED] - #209 - support for comma separated urls in connect() or server()
+* [FIXED] - #206 - incorrect error message when reconnect buffer is overrun
 
 ## Version 2.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 * [ADDED] - #209 - support for comma separated urls in connect() or server()
 * [FIXED] - #206 - incorrect error message when reconnect buffer is overrun
 * [CHANGED] - #214 - moved to an executor instead of 1-off threads
+* [FIXED] - #220 - an icky timing issue that could delay messages
+* [CHANGED] - added larger TCP defaults to improve network performance
+* [ADDED] - public method to create an inbox subject using the prefix from options
 
 ## Version 2.4.1
 

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ The java-nats client is provided in a single jar file, with a single external de
 
 ### Downloading the Jar
 
-You can download the latest jar at [https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.4.1/jnats-2.4.1.jar](https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.4.1/jnats-2.4.1.jar).
+You can download the latest jar at [https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.4.2/jnats-2.4.2.jar](https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.4.2/jnats-2.4.2.jar).
 
-The examples are available at [https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.4.1/jnats-2.4.1-examples.jar](https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.4.1/jnats-2.4.1-examples.jar).
+The examples are available at [https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.4.2/jnats-2.4.2-examples.jar](https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.4.2/jnats-2.4.2-examples.jar).
 
 To use NKeys, you will need the ed25519 library, which can be downloaded at [https://repo1.maven.org/maven2/net/i2p/crypto/eddsa/0.3.0/eddsa-0.3.0.jar](https://repo1.maven.org/maven2/net/i2p/crypto/eddsa/0.3.0/eddsa-0.3.0.jar).
 
@@ -48,7 +48,7 @@ The NATS client is available in the Maven central repository, and can be importe
 
 ```groovy
 dependencies {
-    implementation 'io.nats:jnats:2.4.1'
+    implementation 'io.nats:jnats:2.4.2'
 }
 ```
 
@@ -74,7 +74,7 @@ The NATS client is available on the Maven central repository, and can be importe
 <dependency>
     <groupId>io.nats</groupId>
     <artifactId>jnats</artifactId>
-    <version>2.2.0</version>
+    <version>2.4.2</version>
 </dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,9 +14,9 @@ plugins {
 // Be sure to update Nats.java with the latest version, the change log and the package-info.java
 def versionMajor = 2
 def versionMinor = 4
-def versionPatch = 1
+def versionPatch = 2
 def versionModifier = ""
-def jarVersion = "2.4.1"
+def jarVersion = "2.4.2"
 def branch = System.getenv("TRAVIS_BRANCH");
 
 def getVersionName = { ->

--- a/src/main/java/io/nats/client/Connection.java
+++ b/src/main/java/io/nats/client/Connection.java
@@ -330,4 +330,11 @@ public interface Connection extends AutoCloseable {
      * @return the error text from the last error sent by the server to this client
      */
     public String getLastError();
+
+    /**
+     * @return a new inbox subject, can be used for directed replies from
+     * subscribers. These are guaranteed to be unique, but can be shared and subscribed
+     * to by others.
+     */
+    public String createInbox();
 }

--- a/src/main/java/io/nats/client/Nats.java
+++ b/src/main/java/io/nats/client/Nats.java
@@ -72,7 +72,7 @@ public class Nats {
     /**
      * Current version of the library - {@value #CLIENT_VERSION}
      */
-    public static final String CLIENT_VERSION = "2.4.1";
+    public static final String CLIENT_VERSION = "2.4.2";
 
     /**
      * Current language of the library - {@value #CLIENT_LANGUAGE}

--- a/src/main/java/io/nats/client/Options.java
+++ b/src/main/java/io/nats/client/Options.java
@@ -634,12 +634,7 @@ public class Options {
          * @return the Builder for chaining
          */
         public Builder server(String serverURL) {
-            try {
-                this.servers.add(Options.parseURIForServer(serverURL.trim()));
-            } catch (URISyntaxException e) {
-                throw new IllegalArgumentException("Bad server URL: " + serverURL, e);
-            }
-            return this;
+            return this.servers(serverURL.trim().split(","));
         }
 
         /**

--- a/src/main/java/io/nats/client/Options.java
+++ b/src/main/java/io/nats/client/Options.java
@@ -1021,10 +1021,11 @@ public class Options {
         }
 
         /**
-         * Set the {@link Executor Executor} used to run threaded tasks. The default is a
-         * cached thread pull that names threads after the connection name (or a default).
+         * Set the {@link ExecutorService ExecutorService} used to run threaded tasks. The default is a
+         * cached thread pool that names threads after the connection name (or a default). This executor
+         * is used for reading and writing the underlying sockets as well as for each Dispatcher.
          * 
-         * @param exectuor The Executor to use for connections built with these options.
+         * @param executor The ExecutorService to use for connections built with these options.
          * @return the Builder for chaining
          */
         public Builder executor(ExecutorService executor) {
@@ -1127,7 +1128,7 @@ public class Options {
     }
 
     /**
-     * @return the executor, see {@link Builder#exector(Executor) exector()} in the builder doc
+     * @return the executor, see {@link Builder#executor(ExecutorService) executor()} in the builder doc
      */
     public ExecutorService getExecutor() {
         return this.executor;

--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -598,7 +598,9 @@ class NatsConnection implements Connection {
             try {
                 b.cancel(true);
             } catch (CancellationException e) {
-                processException(e);
+                if (!b.isDone() && !b.isCancelled()) {
+                    processException(e);
+                }
             }
         }
     }
@@ -1466,6 +1468,16 @@ class NatsConnection implements Connection {
     // For testing
     NatsConnectionReader getReader() {
         return this.reader;
+    }
+
+    // For testing
+    NatsConnectionWriter getWriter() {
+        return this.writer;
+    }
+
+    // For testing
+    Future<DataPort> getDataPortFuture() {
+        return this.dataPortFuture;
     }
 
     boolean isDraining() {

--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -634,7 +634,7 @@ class NatsConnection implements Connection {
         if ((this.status == Status.RECONNECTING || this.status == Status.DISCONNECTED)
                 && !this.writer.canQueue(msg, options.getReconnectBufferSize())) {
             throw new IllegalStateException(
-                    "Unable to queue any more messages during reconnect, max buffer is " + getMaxPayload());
+                    "Unable to queue any more messages during reconnect, max buffer is " + options.getReconnectBufferSize());
         }
         queueOutgoing(msg);
     }

--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -754,7 +754,7 @@ class NatsConnection implements Connection {
         }
     }
 
-    String createInbox() {
+    public String createInbox() {
         String prefix = options.getInboxPrefix();
         StringBuilder builder = new StringBuilder();
         builder.append(prefix);

--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -409,7 +409,7 @@ class NatsConnection implements Connection {
         // If we are connecting or disconnecting, note exception and leave
         statusLock.lock();
         try {
-            if (this.connecting || this.disconnecting || this.status == Status.CLOSED) {
+            if (this.connecting || this.disconnecting || this.status == Status.CLOSED || this.isDraining()) {
                 this.exceptionDuringConnectChange = io;
                 return;
             }
@@ -531,10 +531,11 @@ class NatsConnection implements Connection {
         try {
             updateStatus(Status.CLOSED); // will signal, we also signal when we stop disconnecting
 
+            /*
             if (exceptionDuringConnectChange != null) {
                 processException(exceptionDuringConnectChange);
                 exceptionDuringConnectChange = null;
-            }
+            }*/
         } finally {
             statusLock.unlock();
         }

--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -120,8 +120,6 @@ class NatsConnection implements Connection {
 
     private ExecutorService executor;
 
-    ExecutorService getExecutor() { return executor; }
-
     NatsConnection(Options options) {
         this.options = options;
 
@@ -154,7 +152,7 @@ class NatsConnection implements Connection {
 
         this.callbackRunner = Executors.newSingleThreadExecutor();
 
-        this.executor = Executors.newCachedThreadPool();
+        this.executor = options.getExecutor();
     }
 
     // Connect is only called after creation
@@ -1317,6 +1315,10 @@ class NatsConnection implements Connection {
 
     public String getLastError() {
         return this.lastError.get();
+    }
+
+    ExecutorService getExecutor() {
+        return executor;
     }
 
     void updateStatus(Status newStatus) {

--- a/src/main/java/io/nats/client/impl/NatsConnectionReader.java
+++ b/src/main/java/io/nats/client/impl/NatsConnectionReader.java
@@ -17,7 +17,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -71,7 +70,7 @@ class NatsConnectionReader implements Runnable {
 
         this.running = new AtomicBoolean(false);
         this.stopped = new CompletableFuture<>();
-        ((CompletableFuture)this.stopped).complete(Boolean.TRUE); // we are stopped on creation
+        ((CompletableFuture<Boolean>)this.stopped).complete(Boolean.TRUE); // we are stopped on creation
 
         this.protocolBuffer = ByteBuffer.allocate(this.connection.getOptions().getMaxControlLine());
         this.msgLineChars = new char[this.connection.getOptions().getMaxControlLine()];

--- a/src/main/java/io/nats/client/impl/NatsConnectionReader.java
+++ b/src/main/java/io/nats/client/impl/NatsConnectionReader.java
@@ -352,7 +352,7 @@ class NatsConnectionReader implements Runnable {
             } else if (chars[0] == '-' && 
                         (chars[1] == 'E' || chars[1] == 'e') &&
                         (chars[2] == 'R' || chars[2] == 'r') && 
-                        (chars[3] == 'R' || chars[3] == 'R')) {
+                        (chars[3] == 'R' || chars[3] == 'r')) {
                 return NatsConnection.OP_ERR;
             } else if ((chars[0] == 'I' || chars[0] == 'i') && 
                         (chars[1] == 'N' || chars[1] == 'n') && 

--- a/src/main/java/io/nats/client/impl/NatsConnectionReader.java
+++ b/src/main/java/io/nats/client/impl/NatsConnectionReader.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -58,9 +59,8 @@ class NatsConnectionReader implements Runnable {
     
     private byte[] buffer;
     private int bufferPosition;
-    
-    private Thread thread;
-    private CompletableFuture<Boolean> stopped;
+
+    private Future<Boolean> stopped;
     private Future<DataPort> dataPortFuture;
     private final AtomicBoolean running;
 
@@ -71,7 +71,7 @@ class NatsConnectionReader implements Runnable {
 
         this.running = new AtomicBoolean(false);
         this.stopped = new CompletableFuture<>();
-        this.stopped.complete(Boolean.TRUE); // we are stopped on creation
+        ((CompletableFuture)this.stopped).complete(Boolean.TRUE); // we are stopped on creation
 
         this.protocolBuffer = ByteBuffer.allocate(this.connection.getOptions().getMaxControlLine());
         this.msgLineChars = new char[this.connection.getOptions().getMaxControlLine()];
@@ -88,10 +88,7 @@ class NatsConnectionReader implements Runnable {
     void start(Future<DataPort> dataPortFuture) {
         this.dataPortFuture = dataPortFuture;
         this.running.set(true);
-        this.stopped = new CompletableFuture<>(); // New future
-        String name = (this.connection.getOptions().getConnectionName() != null) ? this.connection.getOptions().getConnectionName() : "Nats Connection";
-        this.thread = new Thread(this, name + " Reader");
-        this.thread.start();
+        this.stopped = connection.getExecutor().submit(this, Boolean.TRUE);
     }
 
     // May be called several times on an error.
@@ -102,6 +99,7 @@ class NatsConnectionReader implements Runnable {
         return stopped;
     }
 
+    @Override
     public void run() {
         try {
             DataPort dataPort = this.dataPortFuture.get(); // Will wait for the future to complete
@@ -151,8 +149,6 @@ class NatsConnectionReader implements Runnable {
             // Clear the buffers, since they are only used inside this try/catch
             // We will reuse later
             this.protocolBuffer.clear();
-            this.stopped.complete(Boolean.TRUE);
-            this.thread = null;
         }
     }
 

--- a/src/main/java/io/nats/client/impl/NatsConnectionWriter.java
+++ b/src/main/java/io/nats/client/impl/NatsConnectionWriter.java
@@ -18,7 +18,6 @@ import java.nio.BufferOverflowException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Arrays;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -45,7 +44,7 @@ class NatsConnectionWriter implements Runnable {
         this.running = new AtomicBoolean(false);
         this.reconnectMode = new AtomicBoolean(false);
         this.stopped = new CompletableFuture<>();
-        ((CompletableFuture)this.stopped).complete(Boolean.TRUE); // we are stopped on creation
+        ((CompletableFuture<Boolean>)this.stopped).complete(Boolean.TRUE); // we are stopped on creation
 
         this.sendBuffer = new byte[connection.getOptions().getBufferSize()];
 

--- a/src/main/java/io/nats/client/impl/NatsConsumer.java
+++ b/src/main/java/io/nats/client/impl/NatsConsumer.java
@@ -201,7 +201,7 @@ abstract class NatsConsumer implements Consumer {
 
         // Wait for the timeout or the pending count to go to 0, skipped if conn is
         // draining
-        Thread t = new Thread(() -> {
+        connection.getExecutor().submit(() -> {
             try {
                 Instant now = Instant.now();
 
@@ -223,8 +223,6 @@ abstract class NatsConsumer implements Consumer {
                 tracker.complete(this.isDrained());
             }
        });
-       t.setName("Consumer Drain");
-       t.start();
 
        return getDrainingFuture();
    }

--- a/src/main/java/io/nats/client/impl/NatsDispatcher.java
+++ b/src/main/java/io/nats/client/impl/NatsDispatcher.java
@@ -27,7 +27,7 @@ class NatsDispatcher extends NatsConsumer implements Dispatcher, Runnable {
     private MessageQueue incoming;
     private MessageHandler handler;
 
-    private Future thread;
+    private Future<Boolean> thread;
     private final AtomicBoolean running;
 
     private String id;
@@ -48,9 +48,7 @@ class NatsDispatcher extends NatsConsumer implements Dispatcher, Runnable {
     void start(String id) {
         this.id = id;
         this.running.set(true);
-        String name = (this.connection.getOptions().getConnectionName() != null) ? this.connection.getOptions().getConnectionName() : "Nats Connection";
-
-        thread = connection.getExecutor().submit(this);
+        thread = connection.getExecutor().submit(this, Boolean.TRUE);
     }
 
     boolean breakRunLoop() {

--- a/src/main/java/io/nats/client/impl/NatsMessage.java
+++ b/src/main/java/io/nats/client/impl/NatsMessage.java
@@ -171,9 +171,6 @@ class NatsMessage implements Message {
     }
 
     public String getReplyTo() {
-        if (this.replyTo == null) {
-            return null;
-        }
         return this.replyTo;
     }
 

--- a/src/main/java/io/nats/client/impl/SocketDataPort.java
+++ b/src/main/java/io/nats/client/impl/SocketDataPort.java
@@ -52,7 +52,9 @@ public class SocketDataPort implements DataPort {
             this.port = uri.getPort();
 
             this.socket = new Socket();
-
+            socket.setTcpNoDelay(true);
+            socket.setReceiveBufferSize(2 * 1024 * 1024);
+            socket.setSendBufferSize(2 * 1024 * 1024);
             socket.connect(new InetSocketAddress(host, port), (int) timeout);
 
             in = socket.getInputStream();

--- a/src/test/java/io/nats/client/ConnectTests.java
+++ b/src/test/java/io/nats/client/ConnectTests.java
@@ -188,6 +188,21 @@ public class ConnectTests {
         }
     }
 
+    @Test
+    public void testConnectWithCommas() throws IOException, InterruptedException {
+        try (NatsTestServer ts1 = new NatsTestServer(false)) {
+            try (NatsTestServer ts2 = new NatsTestServer(false)) {
+                Connection nc = Nats.connect(ts1.getURI() + "," + ts2.getURI());
+                try {
+                    assertTrue("Connected Status", Connection.Status.CONNECTED == nc.getStatus());
+                } finally {
+                    nc.close();
+                    assertTrue("Closed Status", Connection.Status.CLOSED == nc.getStatus());
+                }
+            }
+        }
+    }
+
     @Test(expected=IOException.class)
     public void testFailWithMissingLineFeedAfterInfo() throws IOException, InterruptedException {
         Connection nc = null;

--- a/src/test/java/io/nats/client/OptionsTests.java
+++ b/src/test/java/io/nats/client/OptionsTests.java
@@ -426,6 +426,20 @@ public class OptionsTests {
     }
 
     @Test
+    public void testServersWithCommas() {
+        String url1 = "nats://localhost:8080";
+        String url2 = "nats://localhost:8081";
+        String serverURLs = url1 + "," + url2;
+        Options o = new Options.Builder().server(serverURLs).build();
+
+        Collection<URI> servers = o.getServers();
+        URI[] serverArray = servers.toArray(new URI[0]);
+        assertEquals(2, serverArray.length);
+        assertEquals("property server", url1, serverArray[0].toString());
+        assertEquals("property server", url2, serverArray[1].toString());
+    }
+
+    @Test
     public void testEmptyStringInServers() {
         String url1 = "nats://localhost:8080";
         String url2 = "";

--- a/src/test/java/io/nats/client/OptionsTests.java
+++ b/src/test/java/io/nats/client/OptionsTests.java
@@ -27,6 +27,11 @@ import java.time.Duration;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.Properties;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLContext;
 
@@ -488,6 +493,34 @@ public class OptionsTests {
         String[] serverUrls = {url1, url2};
         new Options.Builder().servers(serverUrls).build();
         assertFalse(true);
+    }
+    
+    @Test
+    public void testSetExectuor() {
+        ExecutorService exec = Executors.newCachedThreadPool();
+        Options options = new Options.Builder().executor(exec).build();
+        assertEquals(exec, options.getExecutor());
+    }
+    
+    @Test
+    public void testDefaultExecutor() throws Exception {
+        Options options = new Options.Builder().connectionName("test").build();
+        Future<String> future = options.getExecutor().submit(new Callable<String>(){
+            public String call() {
+                return Thread.currentThread().getName();
+            }
+        });
+        String name = future.get(5, TimeUnit.SECONDS);
+        assertTrue(name.startsWith("test"));
+
+        options = new Options.Builder().build();
+        future = options.getExecutor().submit(new Callable<String>(){
+            public String call() {
+                return Thread.currentThread().getName();
+            }
+        });
+        name = future.get(5, TimeUnit.SECONDS);
+        assertTrue(name.startsWith(Options.DEFAULT_THREAD_NAME_PREFIX));
     }
 
     @Test

--- a/src/test/java/io/nats/client/SubscriberTests.java
+++ b/src/test/java/io/nats/client/SubscriberTests.java
@@ -21,12 +21,29 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.HashSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 
 import org.junit.Test;
 
 public class SubscriberTests {
+
+    @Test
+    public void testCreateInbox() throws IOException, InterruptedException {
+        HashSet<String> check = new HashSet<>();
+        try (NatsTestServer ts = new NatsTestServer(false);
+            Connection nc = Nats.connect(ts.getURI())) {
+            assertTrue("Connected Status", Connection.Status.CONNECTED == nc.getStatus());
+
+            for (int i=0; i < 10_000; i++) {
+                String inbox = nc.createInbox();
+                assertFalse(check.contains(inbox));
+                check.add(inbox);
+            }
+        }
+    }
+
     @Test
     public void testSingleMessage() throws IOException, InterruptedException {
         try (NatsTestServer ts = new NatsTestServer(false);

--- a/src/test/java/io/nats/client/impl/DispatcherTests.java
+++ b/src/test/java/io/nats/client/impl/DispatcherTests.java
@@ -500,7 +500,7 @@ public class DispatcherTests {
             nc.publish("done", new byte[16]); // when we get this we know the others are dispatched
             nc.flush(Duration.ofMillis(5000)); // Wait for the publish
 
-            done.get(2000, TimeUnit.MILLISECONDS); // make sure we got them
+            done.get(5000, TimeUnit.MILLISECONDS); // make sure we got them
             assertTrue("Closed Status", Connection.Status.CLOSED == nc.getStatus());
         }
     }

--- a/src/test/java/io/nats/client/impl/DrainTests.java
+++ b/src/test/java/io/nats/client/impl/DrainTests.java
@@ -714,7 +714,7 @@ public class DrainTests {
 
             assertFalse(tracker.get(3, TimeUnit.SECONDS));
             assertFalse(((NatsConnection) subCon).isDrained());
-            assertTrue(handler.getExceptionCount() > 0);
+            assertTrue(handler.getExceptionCount() == 0); // Don't throw during drain from reader
             assertTrue(Connection.Status.CLOSED == subCon.getStatus());
         }
     }

--- a/src/test/java/io/nats/client/impl/MessageQueueTests.java
+++ b/src/test/java/io/nats/client/impl/MessageQueueTests.java
@@ -100,7 +100,7 @@ public class MessageQueueTests {
 
         Thread t = new Thread(() -> {
             try {
-                Thread.sleep(100);
+                Thread.sleep(500);
                 q.push(new NatsMessage("test"));
             } catch (Exception exp) {
                 // eat the exception, test will fail
@@ -109,7 +109,7 @@ public class MessageQueueTests {
         t.start();
 
         // Thread timing, so could be flaky
-        NatsMessage msg = q.pop(Duration.ofMillis(200));
+        NatsMessage msg = q.pop(Duration.ofMillis(5000));
         assertNotNull(msg);
     }
 


### PR DESCRIPTION
## Version 2.4.2

* [FIXED] - #217 - added check to "ignore" exceptions from reader during drain
* [CHANGED] - no longer call exception handler for "ignored" communication exceptions during close/drain after close occurs
* [ADDED] - #209 - support for comma separated urls in connect() or server()
* [FIXED] - #206 - incorrect error message when reconnect buffer is overrun
* [CHANGED] - #214 - moved to an executor instead of 1-off threads