### PR TITLE
add buffer sizes to tcp socket

### DIFF
--- a/src/main/java/io/nats/client/impl/SocketDataPort.java
+++ b/src/main/java/io/nats/client/impl/SocketDataPort.java
@@ -52,7 +52,9 @@ public class SocketDataPort implements DataPort {
             this.port = uri.getPort();
 
             this.socket = new Socket();
-
+            socket.setTcpNoDelay(true);
+            socket.setReceiveBufferSize(2 * 1024 * 1024);
+            socket.setSendBufferSize(2 * 1024 * 1024);
             socket.connect(new InetSocketAddress(host, port), (int) timeout);
 
             in = socket.getInputStream();


### PR DESCRIPTION
Observed some performance degradation moving from jnats 1 to jnats 2, restoring the tcp socket options from jnats 1 appeard to fix this. (https://github.com/nats-io/java-nats/blob/71f4154ef7a3037356f79a3f63fc20602b505c45/src/main/java/io/nats/client/TcpConnection.java#L69-L73)

@sasbury 