### PR TITLE
2.4.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ jdk:
 - openjdk9
 - openjdk10
 before_script:
-- wget "https://github.com/nats-io/gnatsd/releases/download/$gnatsd_version/gnatsd-$gnatsd_version-linux-amd64.zip"
+- wget "https://github.com/nats-io/nats-server/releases/download/$nats_server_version/gnatsd-$nats_server_version-linux-amd64.zip"
   -O tmp.zip
 - unzip tmp.zip
-- mv gnatsd-$gnatsd_version-linux-amd64 gnatsd
+- mv gnatsd-$nats_server_version-linux-amd64 nats-server
 before_install:
 - openssl aes-256-cbc -K $encrypted_f07928735f08_key -iv $encrypted_f07928735f08_iv
   -in .travis/nats.travis.gpg.enc -out .travis/nats.travis.gpg -d
@@ -32,8 +32,8 @@ after_success:
 #Disable for now, upload archives fails because of IP address changes - "test ${TRAVIS_PULL_REQUEST} != 'true' && test ${TRAVIS_BRANCH} = 'master' && ./gradlew closeAndReleaseRepository"
 env:
   global:
-  - gnatsd_version=v1.3.0
-  - gnatsd_path=$TRAVIS_BUILD_DIR/gnatsd/gnatsd
+  - nats_server_version=v1.4.0
+  - nats_server_path=$TRAVIS_BUILD_DIR/nats-server/gnatsd
   - GPG_KEYRING_FILE=.travis/nats.travis.gpg
   - secure: yvOfk7kJzzTQ38n444jTDets24FZmxewwb3lrhXwpHTwOnQyq/B8QaHeqvhneECMc0Bq5M4blTlJ/wOWJAvs61POv2QVkyw+u8cVNROzkb8GPaH4ybPo8HMl33EHFNqh1KRo2C9hAPMYbbTjKCVY2UdkdfJ2l4lN/Awk7uEDX8ckc/sENhDeQjY/xoGZUP28O568Eg4ZxN3fr3WEV/0T+R15YyL2X0ev8MiGJM5TojXnNFKdb5fkUodRWwiY8JDn5xzP7xUzzen7MqE/5YNTcIC6haU8LToJM2gXEQtdoWLZqMPWr7k4A+eTBO5vl9qWrPBaOodFJYKzEjrEDfHj5RR9uaufEsnwQzXKw1ODrIFVZiC2n73j/tatWDI+vjnJ5tO+VMwWj53qdBYrvYeyewIT3cz9rrDHH8fGINsKAsk6HgWM3SMgeNSuXjRN0ePxEph5FVQ3ZUjF1ZXp90O7kjD5kXg/jVs6GrhCviRT3fx6Z4hyat9ytshy66jqcttHEfJ5sSOBg8fVbWJjLbxmghWUFp1fuc0HGNiMJStEyOBai5AkG6uJccTlgjlNL/8mgEF+fxo8HGVyStQzRnr7LJuCmWW9hx/aBVmqXR4p6cRgsSO09PvHRmcsLQoktCxVxsvcfblQqMbiQKjsJ4tXLe0U88DMOHnEGOgtik/tt+4=
   - secure: isW18c01AJEDAPUUl6rKcewHxOqItTW0TiiEIrWQqQP/C3O06WgAbiFYVFPJ9zCi6me0Wj3YMmEoxiYBhFdgH/O5xoQnnU7xIfD9hcmByglsoyGsK/Wz0wcERoVf9bfbVQkj9q/Mg7kaUZCMWqcFR3CqHEGu8UH5x7ecDW5FXfAQDjN5czT1j1VAwhHZCfIktJuy/GzoFGgRJpvnFPSlHmi0I8fApoX43tmOCkTVHnaXt9CDL3A5EIKtok5dwu0FF5d9hQFncJB8gqGxd+r8a3W3+0Gfgdou3x+AlGTf3R62LgB03GY0MFrMVfanWJE1ORdV0o9hC3AiwOsKBTungZ0arQeXtDXHSeMY52O6u7C8MCwQgbTmzO2YsmMwwTL98PPQxEJ6c8r7WBAfxzxxRTJ/QjPqQdyWV9dFWOnsmEhBLM2Wi858dJlw5fDEoHgy8EUZTQcquUWqEzTJca1VdrLza/PlND8dqfAjxqINtpsXu88JsLUu5VjFiLwln5NpdNKfcY4oaPiLLYdrSgdxBfHCCISP+r8iqgKLDguFwza3xcPSFwqtEq8aYmy0fjgd0c9hlz6oe0NvLc4kPJf4q9NDjffUXBciiv8VXdL3YyRG67h9AF+ndbM8NHsup5FfmALfq2bGIpe4USIqoOAZFUSa35hPDW87C7Z4vvPvb9I=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 
 # Change Log
 
+## Version 2.4.4
+
+* [FIXED] - #230 - removed extra executor allocation
+* [FIXED] - #231 - found a problem with message ordering when filtering pings on reconnect, caused issues with reconnect in general
+* [FIXED] - #226 - added more doc about ping intervals and max ping
+* [FIXED] - #224 - resolved a latency problem with windows due to the cost of the message queues spinwait/lock
+
 ## Version 2.4.3
 
 * [FIXED] - #223 - made SID public in the message

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [FIXED] - #231 - found a problem with message ordering when filtering pings on reconnect, caused issues with reconnect in general
 * [FIXED] - #226 - added more doc about ping intervals and max ping
 * [FIXED] - #224 - resolved a latency problem with windows due to the cost of the message queues spinwait/lock
+* [CHANGED] - started support for renaming gnatsd to nats-server, full release isn't done so using gnatsd for tests still
 
 ## Version 2.4.3
 

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ The java-nats client is provided in a single jar file, with a single external de
 
 ### Downloading the Jar
 
-You can download the latest jar at [https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.4.3/jnats-2.4.3.jar](https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.4.3/jnats-2.4.3.jar).
+You can download the latest jar at [https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.4.4/jnats-2.4.4.jar](https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.4.4/jnats-2.4.4.jar).
 
-The examples are available at [https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.4.3/jnats-2.4.3-examples.jar](https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.4.3/jnats-2.4.3-examples.jar).
+The examples are available at [https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.4.4/jnats-2.4.4-examples.jar](https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.4.4/jnats-2.4.4-examples.jar).
 
 To use NKeys, you will need the ed25519 library, which can be downloaded at [https://repo1.maven.org/maven2/net/i2p/crypto/eddsa/0.3.0/eddsa-0.3.0.jar](https://repo1.maven.org/maven2/net/i2p/crypto/eddsa/0.3.0/eddsa-0.3.0.jar).
 
@@ -48,7 +48,7 @@ The NATS client is available in the Maven central repository, and can be importe
 
 ```groovy
 dependencies {
-    implementation 'io.nats:jnats:2.4.3'
+    implementation 'io.nats:jnats:2.4.4'
 }
 ```
 
@@ -74,7 +74,7 @@ The NATS client is available on the Maven central repository, and can be importe
 <dependency>
     <groupId>io.nats</groupId>
     <artifactId>jnats</artifactId>
-    <version>2.4.3</version>
+    <version>2.4.4</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ A [Java](http://java.com) client for the [NATS messaging system](https://nats.io
 
 ## A Note on Versions
 
+The NATS server renamed itself from gnatsd to nats-server around 2.4.4. This and other files try to use the new names, but some underlying code may change over several versions. If you are building yourself, please keep an eye out for issues and report them.
+
 This is version 2.1 of the java-nats library. This version is a ground up rewrite of the original library. Part of the goal of this re-write was to address the excessive use of threads, we created a Dispatcher construct to allow applications to control thread creation more intentionally. This version also removes all non-JDK runtime dependencies.
 
 The API is [simple to use](#listening-for-incoming-messages) and highly [performant](#Benchmarking).
@@ -101,7 +103,7 @@ NATS uses RNG to generate unique inbox names. A peculiarity of the JDK on Linux 
 
 ## Basic Usage
 
-Sending and receiving with NATS is as simple as connecting to the gnatsd and publishing or subscribing for messages. A number of examples are provided in this repo as described in [examples.md](src/examples/java/io/nats/examples/examples.md).
+Sending and receiving with NATS is as simple as connecting to the nats-server and publishing or subscribing for messages. A number of examples are provided in this repo as described in [examples.md](src/examples/java/io/nats/examples/examples.md).
 
 ### Connecting
 
@@ -232,7 +234,7 @@ If you want to try out these techniques, take a look at the [examples.md](src/ex
 
 ### Clusters & Reconnecting
 
-The Java client will automatically reconnect if it loses its connection the gnatsd. If given a single server, the client will keep trying that one. If given a list of servers, the client will rotate between them. When the gnatsd servers are in a cluster, they will tell the client about the other servers, so that in the simplest case a client could connect to one server, learn about the cluster and reconnect to another server if its initial one goes down.
+The Java client will automatically reconnect if it loses its connection the nats-server. If given a single server, the client will keep trying that one. If given a list of servers, the client will rotate between them. When the nats servers are in a cluster, they will tell the client about the other servers, so that in the simplest case a client could connect to one server, learn about the cluster and reconnect to another server if its initial one goes down.
 
 To tell the connection about multiple servers for the initial connection, use the `servers()` method on the options builder, or call `server()` multiple times.
 
@@ -245,7 +247,7 @@ Reconnection behavior is controlled via a few options, see the javadoc for the O
 
 ## Benchmarking
 
-The `io.nats.examples` package contains two benchmarking tools, modeled after tools in other NATS clients. Both examples run against an existing gnatsd. The first called `io.nats.examples.benchmark.NatsBench` runs two simple tests, the first simply publishes messages, the second also receives messages. Tests are run with 1 thread/connection per publisher or subscriber. Running on an iMac (2017), with 4.2 GHz Intel Core i7 and 64GB of memory produced results like:
+The `io.nats.examples` package contains two benchmarking tools, modeled after tools in other NATS clients. Both examples run against an existing nats-server. The first called `io.nats.examples.benchmark.NatsBench` runs two simple tests, the first simply publishes messages, the second also receives messages. Tests are run with 1 thread/connection per publisher or subscriber. Running on an iMac (2017), with 4.2 GHz Intel Core i7 and 64GB of memory produced results like:
 
 ```AsciiDoc
 Starting benchmark(s) [msgs=5000000, msgsize=256, pubs=2, subs=2]
@@ -371,7 +373,7 @@ The java doc is located in `build/docs` and the example jar is in `build/libs`. 
 
 which will create a folder called `build/reports/jacoco` containing the file `index.html` you can open and use to browse the coverage. Keep in mind we have focused on library test coverage, not coverage for the examples.
 
-Many of the tests run gnatsd on a custom port. If gnatsd is in your path they should just work, but in cases where it is not, or an IDE running tests has issues with the path you can specify the gnatsd location with the environment variable `gnatsd_path`.
+Many of the tests run nats-server on a custom port. If nats-server is in your path they should just work, but in cases where it is not, or an IDE running tests has issues with the path you can specify the nats-server location with the environment variable `nats_-_server_path`.
 
 ## License
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,9 +14,9 @@ plugins {
 // Be sure to update Nats.java with the latest version, the change log and the package-info.java
 def versionMajor = 2
 def versionMinor = 4
-def versionPatch = 3
+def versionPatch = 4
 def versionModifier = ""
-def jarVersion = "2.4.3"
+def jarVersion = "2.4.4"
 def branch = System.getenv("TRAVIS_BRANCH");
 
 def getVersionName = { ->

--- a/src/examples/java/io/nats/examples/RawTCPLatencyTest.java
+++ b/src/examples/java/io/nats/examples/RawTCPLatencyTest.java
@@ -1,0 +1,93 @@
+package io.nats.examples;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class RawTCPLatencyTest {
+
+    static boolean isServer;
+    static String host = "localhost";
+    static int port = 1234;
+    static int warmIters = 1000, runIters = 10000;
+
+    static InputStream in;
+    static OutputStream out;
+
+    public static void main(String[] args) {
+        if (args.length < 1) {
+            System.out.println("Parameters: server/client host port");
+            return;
+        }
+        isServer = args[0].startsWith("s");
+        if (args.length > 1) {
+            host = args[1];
+        }
+        if (args.length > 2) {
+            port = Integer.parseInt(args[2]);
+        }
+        try {
+            if (isServer) {
+                runServer();
+            } else {
+                runClient();
+            }
+        } catch (IOException ex) {
+            Logger.getLogger(RawTCPLatencyTest.class.getName()).log(Level.SEVERE, null, ex);
+        }
+    }
+
+    private static void runServer() throws IOException {
+        ServerSocket serverSocket = new ServerSocket(port);
+        while (true) {
+            Socket socket = serverSocket.accept();
+            System.out.println("Connected");
+            socket.setTcpNoDelay(true);
+            socket.setReceiveBufferSize(2 * 1024 * 1024);
+            socket.setSendBufferSize(2 * 1024 * 1024);
+            in = socket.getInputStream();
+            out = socket.getOutputStream();
+            try {
+                while (true) {
+                    int rq = in.read();
+                    out.write(rq);
+                }
+            } catch (IOException e) {
+                System.out.println("Disconnected");
+            }
+        }
+    }
+
+    private static void runClient() throws SocketException, IOException {
+        Socket socket = new Socket();
+        socket.setTcpNoDelay(true);
+        socket.setReceiveBufferSize(2 * 1024 * 1024);
+        socket.setSendBufferSize(2 * 1024 * 1024);
+        socket.connect(new InetSocketAddress(host, port), 1000);
+        in = socket.getInputStream();
+        out = socket.getOutputStream();
+        System.out.println("Connected");
+        for (int i = 0; i < warmIters; i++) {
+            sendRecv();
+        }
+        System.out.println("Warmed");
+        long t0 = System.nanoTime();
+        for (int i = 0; i < runIters; i++) {
+            sendRecv();
+        }
+        long t1 = System.nanoTime();
+        System.out.println("Average latency " + (1.0 * (t1 - t0)) / (1000000.0 * runIters) + " ms");
+        socket.close();
+    }
+
+    private static void sendRecv() throws IOException {
+        out.write(11);
+        in.read();
+    }
+}

--- a/src/examples/java/io/nats/examples/autobench/NatsAutoBench.java
+++ b/src/examples/java/io/nats/examples/autobench/NatsAutoBench.java
@@ -38,6 +38,7 @@ public class NatsAutoBench {
         boolean utf8 = false;
         int baseMsgs = 100_000;
         int latencyMsgs = 5_000;
+        long maxSize = 8*1024;
 
         if (args.length > 0) {
             for (String s : args) {
@@ -49,12 +50,15 @@ public class NatsAutoBench {
                 }  else if (s.equals("small")) {
                     baseMsgs = 5_000;
                     latencyMsgs = 250;
+                    maxSize = 1024;
                 } else if (s.equals("tiny")) {
                     baseMsgs = 1_000;
                     latencyMsgs = 50;
+                    maxSize = 1024;
                 } else if (s.equals("nano")) {
                     baseMsgs = 10;
                     latencyMsgs = 5;
+                    maxSize = 512;
                 } else if (s.equals("help")) {
                     usage();
                     return;
@@ -78,7 +82,7 @@ public class NatsAutoBench {
             }
                     
             Options connectOptions = builder.build();                   
-            List<AutoBenchmark> tests = buildTestList(baseMsgs, latencyMsgs);
+            List<AutoBenchmark> tests = buildTestList(baseMsgs, latencyMsgs, maxSize);
 
             System.out.println("Running warmup");
             runWarmup(connectOptions);
@@ -125,7 +129,7 @@ public class NatsAutoBench {
     }
 
     public static void runWarmup(Options connectOptions) throws Exception {
-        AutoBenchmark warmup = (new PubSubBenchmark("warmup", 1_000_000, 64));
+        AutoBenchmark warmup = (new PubSubBenchmark("warmup", 100_000, 64));
         warmup.execute(connectOptions);
 
         if (warmup.getException() != null) {
@@ -134,56 +138,69 @@ public class NatsAutoBench {
         }
     }
 
-    public static List<AutoBenchmark> buildTestList(int baseMsgs, int latencyMsgs) {
+    public static List<AutoBenchmark> buildTestList(int baseMsgs, int latencyMsgs, long maxSize) {
         ArrayList<AutoBenchmark> tests = new ArrayList<>();
         
-        /**/
-        tests.add(new PubBenchmark("PubOnly 0b", 100 * baseMsgs, 0));
-        tests.add(new PubBenchmark("PubOnly 8b", 100 * baseMsgs, 8));
-        tests.add(new PubBenchmark("PubOnly 32b", 100 * baseMsgs, 32));
-        tests.add(new PubBenchmark("PubOnly 256b", 100 * baseMsgs, 256));
-        tests.add(new PubBenchmark("PubOnly 512b", 100 * baseMsgs, 512));
-        tests.add(new PubBenchmark("PubOnly 1k", 10 * baseMsgs, 1024));
-        tests.add(new PubBenchmark("PubOnly 4k", 5 * baseMsgs, 4*1024));
-        tests.add(new PubBenchmark("PubOnly 8k", baseMsgs, 8*1024));
+        int[] sizes = {0, 8, 32, 256, 512, 1024, 4*1024, 8*1024};
+        int[] msgsMultiple = {100, 100, 100, 100, 100, 10, 5, 1};
+        int[] msgsDivider = {5, 5, 10, 10, 10, 10, 10, 10};
 
-        tests.add(new PubSubBenchmark("PubSub 0b", 100 * baseMsgs, 0));
-        tests.add(new PubSubBenchmark("PubSub 8b", 100 * baseMsgs, 8));
-        tests.add(new PubSubBenchmark("PubSub 32b", 100 * baseMsgs, 32));
-        tests.add(new PubSubBenchmark("PubSub 256b", 100 * baseMsgs, 256));
-        tests.add(new PubSubBenchmark("PubSub 512b", 50 * baseMsgs, 512));
-        tests.add(new PubSubBenchmark("PubSub 1k", 10 * baseMsgs, 1024));
-        tests.add(new PubSubBenchmark("PubSub 4k", baseMsgs, 4*1024));
-        tests.add(new PubSubBenchmark("PubSub 8k", baseMsgs, 8*1024));
-        
-        tests.add(new PubDispatchBenchmark("PubDispatch 0b", 100 * baseMsgs, 0));
-        tests.add(new PubDispatchBenchmark("PubDispatch 8b", 100 * baseMsgs, 8));
-        tests.add(new PubDispatchBenchmark("PubDispatch 32b", 100 * baseMsgs, 32));
-        tests.add(new PubDispatchBenchmark("PubDispatch 256b", 100 * baseMsgs, 256));
-        tests.add(new PubDispatchBenchmark("PubDispatch 512b", 50 * baseMsgs, 512));
-        tests.add(new PubDispatchBenchmark("PubDispatch 1k", 10 * baseMsgs, 1024));
-        tests.add(new PubDispatchBenchmark("PubDispatch 4k", baseMsgs, 4*1024));
-        tests.add(new PubDispatchBenchmark("PubDispatch 8k", baseMsgs, 8*1024));
-        
+        /**/
+        for(int i=0; i<sizes.length; i++) {
+            int size = sizes[i];
+            int msgMult = msgsMultiple[i];
+
+            if(size > maxSize) {
+                break;
+            }
+
+            tests.add(new PubBenchmark("PubOnly "+size, msgMult * baseMsgs, size));
+        }
+
+        for(int i=0; i<sizes.length; i++) {
+            int size = sizes[i];
+            int msgMult = msgsMultiple[i];
+
+            if(size > maxSize) {
+                break;
+            }
+
+            tests.add(new PubSubBenchmark("PubSub "+size, msgMult * baseMsgs, size));
+        }
+
+        for(int i=0; i<sizes.length; i++) {
+            int size = sizes[i];
+            int msgMult = msgsMultiple[i];
+
+            if(size > maxSize) {
+                break;
+            }
+
+            tests.add(new PubDispatchBenchmark("PubDispatch "+size, msgMult * baseMsgs, size));
+        }
+
         // Request reply is a 4 message trip, and runs the full loop before sending another message
         // so we run fewer because the client cannot batch any socket calls to the server together
-        tests.add(new ReqReplyBenchmark("ReqReply 0b", baseMsgs / 5, 0));
-        tests.add(new ReqReplyBenchmark("ReqReply 8b", baseMsgs / 5, 8));
-        tests.add(new ReqReplyBenchmark("ReqReply 32b", baseMsgs / 10, 32));
-        tests.add(new ReqReplyBenchmark("ReqReply 256b", baseMsgs / 10, 256));
-        tests.add(new ReqReplyBenchmark("ReqReply 512b", baseMsgs / 10, 512));
-        tests.add(new ReqReplyBenchmark("ReqReply 1k", baseMsgs / 10, 1024));
-        tests.add(new ReqReplyBenchmark("ReqReply 4k", baseMsgs / 10, 4*1024));
-        tests.add(new ReqReplyBenchmark("ReqReply 8k", baseMsgs / 10, 8*1024));
+        for(int i=0; i<sizes.length; i++) {
+            int size = sizes[i];
+            int msgDivide = msgsDivider[i];
 
-        tests.add(new LatencyBenchmark("Latency 0b", latencyMsgs, 0));
-        tests.add(new LatencyBenchmark("Latency 8b", latencyMsgs, 8));
-        tests.add(new LatencyBenchmark("Latency 32b", latencyMsgs, 32));
-        tests.add(new LatencyBenchmark("Latency 256b", latencyMsgs, 256));
-        tests.add(new LatencyBenchmark("Latency 512b", latencyMsgs, 512));
-        tests.add(new LatencyBenchmark("Latency 1k", latencyMsgs, 1024));
-        tests.add(new LatencyBenchmark("Latency 4k", latencyMsgs, 4 * 1024));
-        tests.add(new LatencyBenchmark("Latency 8k", latencyMsgs, 8 * 1024));
+            if(size > maxSize) {
+                break;
+            }
+
+            tests.add(new ReqReplyBenchmark("ReqReply "+size, baseMsgs / msgDivide, size));
+        }
+
+        for(int i=0; i<sizes.length; i++) {
+            int size = sizes[i];
+
+            if(size > maxSize) {
+                break;
+            }
+
+            tests.add(new LatencyBenchmark("Latency "+size, latencyMsgs, size));
+        }
         /**/
 
         return tests;

--- a/src/examples/java/io/nats/examples/autobench/NatsAutoBench.java
+++ b/src/examples/java/io/nats/examples/autobench/NatsAutoBench.java
@@ -68,7 +68,7 @@ public class NatsAutoBench {
             }
         }
 
-        System.out.printf("Connecting to gnatsd at %s\n", server);
+        System.out.printf("Connecting to NATS server at %s\n", server);
 
         try {
             Options.Builder builder = new Options.Builder().

--- a/src/examples/java/io/nats/examples/examples.md
+++ b/src/examples/java/io/nats/examples/examples.md
@@ -39,16 +39,16 @@ To run with the completely unverified client:
 java -cp build/libs/jnats-2.0.0.jar:build/libs/jnats-examples-2.0.0.jar io.nats.examples.NatsSub opentls://localhost:4443 test 3
 ```
 
-There are a set tls configuration for the server in the test files that can be used to run gnatsd.
+There are a set tls configuration for the server in the test files that can be used to run the NATS server.
 
 ```bash
-gnatsd --conf src/test/resources/tls.conf
+nats-server --conf src/test/resources/tls.conf
 ```
 
 As well as one with the verify flag set.
 
 ```bash
-gnatsd --conf src/test/resources/tlsverify.conf
+nats-server --conf src/test/resources/tlsverify.conf
 ```
 
 which will require client certificates.

--- a/src/main/java/io/nats/client/Connection.java
+++ b/src/main/java/io/nats/client/Connection.java
@@ -20,7 +20,7 @@ import java.util.concurrent.TimeoutException;
 
 /**
  * The Connection class is at the heart of the NATS Java client. Fundamentally a connection represents
- * a single network connection to the gnatsd server.
+ * a single network connection to the NATS server.
  * 
  * <p>Each connection you create will result in the creation of a single socket and several threads:
  * <ul>
@@ -72,7 +72,7 @@ import java.util.concurrent.TimeoutException;
  * 
  * <p><em>Note</em>: The publish methods take an array of bytes. These arrays <strong>will not be copied</strong>. This design choice
  * is based on the common case of strings or objects being converted to bytes. Once a client can be sure a message was received by
- * the gnatsd it is theoretically possible to reuse that byte array, but this pattern should be treated as advanced and only used
+ * the NATS server it is theoretically possible to reuse that byte array, but this pattern should be treated as advanced and only used
  * after thorough testing. 
  */
 public interface Connection extends AutoCloseable {

--- a/src/main/java/io/nats/client/ConnectionListener.java
+++ b/src/main/java/io/nats/client/ConnectionListener.java
@@ -19,7 +19,7 @@ package io.nats.client;
  */
 public interface ConnectionListener {
     public enum Events {
-        /** The connection has successfully completed the handshake with the gnatsd. */
+        /** The connection has successfully completed the handshake with the nats-server. */
         CONNECTED("nats: connection opened"),
         /** The connection is permanently closed, either by manual action or failed reconnects. */
         CLOSED("nats: connection closed"),

--- a/src/main/java/io/nats/client/NKey.java
+++ b/src/main/java/io/nats/client/NKey.java
@@ -77,7 +77,7 @@ class DecodedSeed {
  * </p>
  * <p>
  * The NKey libraries encode 32 byte public keys using Base32 and a CRC16
- * checksum plus a prefix based on the key type, e.g. “U...” for a user key.
+ * checksum plus a prefix based on the key type, e.g. U for a user key.
  * </p>
  * <p>
  * The NKey libraries have support for exporting a 64 byte private key. This

--- a/src/main/java/io/nats/client/Nats.java
+++ b/src/main/java/io/nats/client/Nats.java
@@ -72,7 +72,7 @@ public class Nats {
     /**
      * Current version of the library - {@value #CLIENT_VERSION}
      */
-    public static final String CLIENT_VERSION = "2.4.3";
+    public static final String CLIENT_VERSION = "2.4.4";
 
     /**
      * Current language of the library - {@value #CLIENT_LANGUAGE}

--- a/src/main/java/io/nats/client/Nats.java
+++ b/src/main/java/io/nats/client/Nats.java
@@ -19,14 +19,14 @@ import io.nats.client.impl.NatsImpl;
 
 /**
  * The Nats class is the entry point into the NATS client for Java. This class
- * is used to create a connection to the Nats server, gnatsd. Connecting is a
+ * is used to create a connection to the NATS server. Connecting is a
  * synchronous process, with a new asynchronous version available for experimenting.
  * 
  * <p>Simple connections can be created with a URL, while more control is provided
  * when an {@link Options Options} object is used. There are a number of options that
  * effect every connection, as described in the {@link Options Options} documentation.
  * 
- * <p>At its simplest, you can connect to a gnatsd on the local host using the default port with:
+ * <p>At its simplest, you can connect to a nats-server on the local host using the default port with:
  * <pre>Connection nc = Nats.connect()</pre>
  * <p>and start sending or receiving messages immediately after that.
  * 

--- a/src/main/java/io/nats/client/Options.java
+++ b/src/main/java/io/nats/client/Options.java
@@ -906,7 +906,15 @@ public class Options {
 
         /**
          * Set the interval between attempts to pings the server. These pings are automated,
-         * and capped by {@link #maxPingsOut(int) maxPingsOut()}.
+         * and capped by {@link #maxPingsOut(int) maxPingsOut()}. As of 2.4.4 the library
+         * may way up to 2 * time to send a ping. Incoming traffic from the server can postpone
+         * the next ping to avoid pings taking up bandwidth during busy messaging.
+         * 
+         * Keep in mind that a ping requires a round trip to the server. Setting this value to a small
+         * number can result in quick failures due to maxPingsOut being reached, these failures will
+         * force a disconnect/reconnect which can result in messages being held back or failed. In general,
+         * the ping interval should be set in seconds but this value is not enforced as it would result in
+         * an API change from the 2.0 release.
          * 
          * @param time the time between client to server pings
          * @return the Builder for chaining
@@ -956,6 +964,10 @@ public class Options {
          * Set the maximum number of bytes to buffer in the client when trying to
          * reconnect. When this value is exceeded the client will start to drop messages.
          * The count of dropped messages can be read from the {@link Statistics#getDroppedCount() Statistics}.
+         * 
+         * A value of zero will disable the reconnect buffer, a value less than zero means unlimited. Caution
+         * should be used for negative numbers as they can result in an unreliable network connection plus a
+         * high message rate leading to an out of memory error.
          * 
          * @param size the size in bytes
          * @return the Builder for chaining

--- a/src/main/java/io/nats/client/Options.java
+++ b/src/main/java/io/nats/client/Options.java
@@ -709,7 +709,7 @@ public class Options {
         /**
          * Turn off server pool randomization. By default the server will pick
          * servers from its list randomly on a reconnect. When set to noRandom the server
-         * goes in the order they were configured or provided by gnatsd.
+         * goes in the order they were configured or provided by a server in a cluster update.
          * @return the Builder for chaining
          */
         public Builder noRandomize() {
@@ -718,7 +718,7 @@ public class Options {
         }
 
         /**
-         * Turn off echo. If supported by the gnatsd version you are connecting to this
+         * Turn off echo. If supported by the nats-server version you are connecting to this
          * flag will prevent the server from echoing messages back to the connection if it
          * has subscriptions on the subject being published to.
          * @return the Builder for chaining

--- a/src/main/java/io/nats/client/Options.java
+++ b/src/main/java/io/nats/client/Options.java
@@ -1116,7 +1116,6 @@ public class Options {
 
             if (this.executor == null) {
                 String threadPrefix = (this.connectionName != null && this.connectionName != "") ? this.connectionName : DEFAULT_THREAD_NAME_PREFIX;
-                this.executor = Executors.newCachedThreadPool();
                 this.executor = new ThreadPoolExecutor(0, Integer.MAX_VALUE,
                                                         500L, TimeUnit.MILLISECONDS,
                                                         new SynchronousQueue<Runnable>(),

--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -190,7 +190,7 @@ class NatsConnection implements Connection {
                 reconnect();
             } else {
                 close();
-                throw new IOException("Unable to connect to gnatsd server.");
+                throw new IOException("Unable to connect to NATS server.");
             }
         }
     }

--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -110,6 +110,8 @@ class NatsConnection implements Connection {
     private AtomicReference<NatsDispatcher> inboxDispatcher;
     private Timer timer;
 
+    private AtomicBoolean needPing;
+
     private AtomicLong nextSid;
     private NUID nuid;
 
@@ -156,6 +158,8 @@ class NatsConnection implements Connection {
 
         this.executor = options.getExecutor();
         this.connectExecutor = Executors.newSingleThreadExecutor();
+
+        this.needPing = new AtomicBoolean(true);
     }
 
     // Connect is only called after creation
@@ -1032,6 +1036,13 @@ class NatsConnection implements Connection {
             return retVal;
         }
 
+        if (!treatAsInternal && !this.needPing.get()) {
+            CompletableFuture<Boolean> retVal = new CompletableFuture<Boolean>();
+            retVal.complete(Boolean.TRUE);
+            this.needPing.set(true);
+            return retVal;
+        }
+
         if (max > 0 && pongQueue.size() + 1 > max) {
             handleCommunicationIssue(new IllegalStateException("Max outgoing Ping count exceeded."));
             return null;
@@ -1047,6 +1058,7 @@ class NatsConnection implements Connection {
             queueOutgoing(msg);
         }
 
+        this.needPing.set(true);
         this.statistics.incrementPingCount();
         return pongFuture;
     }
@@ -1151,6 +1163,7 @@ class NatsConnection implements Connection {
     }
 
     void deliverMessage(NatsMessage msg) {
+        this.needPing.set(false);
         this.statistics.incrementInMsgs();
         this.statistics.incrementInBytes(msg.getSizeInBytes());
 

--- a/src/main/java/io/nats/client/impl/NatsConnectionWriter.java
+++ b/src/main/java/io/nats/client/impl/NatsConnectionWriter.java
@@ -96,7 +96,7 @@ class NatsConnectionWriter implements Runnable {
     @Override
     public void run() {
         Duration waitForMessage = Duration.ofMinutes(2); // This can be long since no one is sending
-        Duration reconnectWait = Duration.ofMillis(1); // This can be long since no one is sending
+        Duration reconnectWait = Duration.ofMillis(1); // This should be short, since we are trying to get the reconnect through
         long maxMessages = 1000;
 
         try {
@@ -107,7 +107,7 @@ class NatsConnectionWriter implements Runnable {
                 int sendPosition = 0;
                 NatsMessage msg = null;
                 
-                if (reconnectMode.get()) {
+                if (this.reconnectMode.get()) {
                     msg = this.reconnectOutgoing.accumulate(this.sendBuffer.length, maxMessages, reconnectWait);
                 } else {
                     msg = this.outgoing.accumulate(this.sendBuffer.length, maxMessages, waitForMessage);

--- a/src/main/java/io/nats/client/package-info.java
+++ b/src/main/java/io/nats/client/package-info.java
@@ -12,8 +12,8 @@
 // limitations under the License.
 
 /**
- * The Java Nats client is encapsulated into this single package {@code io.nats.client}. Applications
- * will start from the {@link io.nats.client.Nats Nats} class to connect to the gnatsd server. Once connected, they can
+ * The Java NATS client is encapsulated into this single package {@code io.nats.client}. Applications
+ * will start from the {@link io.nats.client.Nats Nats} class to connect to the NATS server. Once connected, they can
  * use the {@link io.nats.client.Connection Connection} object to publish messages or create subscriptions.
  * 
  * @since 2.0.0

--- a/src/test/java/io/nats/client/AuthTests.java
+++ b/src/test/java/io/nats/client/AuthTests.java
@@ -470,7 +470,7 @@ public class AuthTests {
         assertNotNull(theKey);
 
         String configFile = createNKeyConfigFile(theKey.getPublicKey());
-        String version = NatsTestServer.generateGnatsdVersionString();
+        String version = NatsTestServer.generateNatsServerVersionString();
 
         if (!version.contains("version 2")) {
             // Server version doesn't support this test
@@ -498,7 +498,7 @@ public class AuthTests {
         NKey theKey = NKey.createUser(null);
         assertNotNull(theKey);
 
-        String version = NatsTestServer.generateGnatsdVersionString();
+        String version = NatsTestServer.generateNatsServerVersionString();
 
         if (!version.contains("version 2")) {
             // Server version doesn't support this test
@@ -527,7 +527,7 @@ public class AuthTests {
         assertNotNull(theKey);
 
         String configFile = createNKeyConfigFile(theKey.getPublicKey());
-        String version = NatsTestServer.generateGnatsdVersionString();
+        String version = NatsTestServer.generateNatsServerVersionString();
 
         if (!version.contains("version 2")) {
             // Server version doesn't support this test

--- a/src/test/java/io/nats/client/NatsTestServer.java
+++ b/src/test/java/io/nats/client/NatsTestServer.java
@@ -31,7 +31,7 @@ import java.util.regex.Pattern;
  */
 public class NatsTestServer implements AutoCloseable {
 
-    private static final String GNATSD = "gnatsd";
+    private static final String NATS_SERVER = "gnatsd";
 
     // Use a new port each time, we increment and get so start at the normal port
     private static AtomicInteger portCounter = new AtomicInteger(Options.DEFAULT_PORT + 1);
@@ -44,16 +44,16 @@ public class NatsTestServer implements AutoCloseable {
     private String[] customArgs;
     private String[] configInserts;
 
-    public static String generateGnatsdVersionString() {
+    public static String generateNatsServerVersionString() {
         ArrayList<String> cmd = new ArrayList<String>();
 
-        String gnatsd = System.getenv("gnatsd_path");
+        String server_path = System.getenv("nats_server_path");
 
-        if(gnatsd == null){
-            gnatsd = NatsTestServer.GNATSD;
+        if(server_path == null){
+            server_path = NatsTestServer.NATS_SERVER;
         }
 
-        cmd.add(gnatsd);
+        cmd.add(server_path);
         cmd.add("--version");
 
         try {
@@ -139,13 +139,13 @@ public class NatsTestServer implements AutoCloseable {
     public void start() {
         ArrayList<String> cmd = new ArrayList<String>();
 
-        String gnatsd = System.getenv("gnatsd_path");
+        String server_path = System.getenv("nats_server_path");
 
-        if(gnatsd == null){
-            gnatsd = NatsTestServer.GNATSD;
+        if(server_path == null){
+            server_path = NatsTestServer.NATS_SERVER;
         }
 
-        cmd.add(gnatsd);
+        cmd.add(server_path);
 
         // Rewrite the port to a new one, so we don't reuse the same one over and over
         if (this.configFilePath != null) {
@@ -252,8 +252,8 @@ public class NatsTestServer implements AutoCloseable {
         } catch (IOException ex) {
             System.out.println("%%% Failed to start [" + this.cmdLine + "] with message:");
             System.out.println("\t" + ex.getMessage());
-            System.out.println("%%% Make sure that gnatsd is installed and in your PATH.");
-            System.out.println("%%% See https://github.com/nats-io/gnatsd for information on installing gnatsd");
+            System.out.println("%%% Make sure that the nats-server is installed and in your PATH.");
+            System.out.println("%%% See https://github.com/nats-io/nats-server for information on installation");
 
             throw new IllegalStateException("Failed to run [" + this.cmdLine +"]");
         }

--- a/src/test/java/io/nats/client/ReconnectCheck.java
+++ b/src/test/java/io/nats/client/ReconnectCheck.java
@@ -1,0 +1,75 @@
+package io.nats.client;
+
+import java.io.IOException;
+import java.time.Duration;
+
+/* Program to reproduce #231 */
+public class ReconnectCheck {
+    private static long received;
+    private static long published;
+
+    private static long lastReceivedId;
+
+    public static void main(String []args) throws IOException, InterruptedException {
+        Connection natsIn = Nats.connect(buildOptions("IN"));
+        Connection natsOut = Nats.connect(buildOptions("OUT"));
+
+        Dispatcher natsDispatcher = natsIn.createDispatcher(m -> {
+            long receivedId = Long.parseLong(new String(m.getData()));
+
+            if (receivedId < lastReceivedId) {
+                System.out.println(String.format("##### Tid: %d, Received stale data: got %d, last received %d", Thread.currentThread().getId(), receivedId, lastReceivedId));
+            }
+            lastReceivedId = receivedId;
+
+            if (received++ % 1_000_000 == 0) {
+                System.out.println(String.format("Tid: %d, Received %d messages", Thread.currentThread().getId(), received));
+            }
+        });
+
+        natsDispatcher.subscribe("foo");
+
+        long id = 0;
+
+        while (true) {
+            for (int i = 0; i < 100_000; i++) {
+                natsOut.publish("foo", ("" + id++).getBytes());
+                if (published++ % 1_000_000 == 0) {
+                    System.out.println(String.format("Tid: %d, Published %d messages.", Thread.currentThread().getId(), published));
+                }
+            }
+            Thread.sleep(1);
+        }
+    }
+
+    private static Options buildOptions(String name) {
+        Options.Builder natsOptions = new Options.Builder().servers(new String[]{"nats://127.0.0.1:4222"})
+                .connectionName(name);
+        natsOptions.maxReconnects(-1).reconnectWait(Duration.ofSeconds(1))
+                .connectionTimeout(Duration.ofSeconds(5));
+        natsOptions.pingInterval(Duration.ofMillis(100));
+        natsOptions.connectionListener((conn, e) ->
+                System.out.println(String.format("Tid: %d, %s, NATS: connection event - %s, connected url: %s. servers: %s ", Thread.currentThread().getId(), name, e, conn.getConnectedUrl(), conn.getServers())
+        ));
+        natsOptions.errorListener(new ErrorListener() {
+            @Override
+            public void slowConsumerDetected(Connection conn, Consumer consumer) {
+                System.out.println(String.format("Tid: %d, %s, %s: Slow Consumer", Thread.currentThread().getId(), name, conn.getConnectedUrl()));
+            }
+
+            @Override
+            public void exceptionOccurred(Connection conn, Exception exp) {
+                System.out.println(String.format("Tid: %d, %s, Nats '%s' exception: %s", Thread.currentThread().getId(), name, conn.getConnectedUrl(), exp.toString()));
+            }
+
+            @Override
+            public void errorOccurred(Connection conn, String error) {
+                System.out.println(String.format("Tid: %d, %s, Nats '%s': Error %s", Thread.currentThread().getId(), name, conn.getConnectedUrl(), error.toString()));
+            }
+        });
+
+        // Do not cache any messages when Nats connection is down.
+        natsOptions.reconnectBufferSize(-1);
+        return natsOptions.build();
+    }
+}

--- a/src/test/java/io/nats/client/impl/MessageQueueBenchmark.java
+++ b/src/test/java/io/nats/client/impl/MessageQueueBenchmark.java
@@ -25,8 +25,10 @@ public class MessageQueueBenchmark {
 
         System.out.printf("Running benchmarks with %s messages.\n", NumberFormat.getInstance().format(msgCount));
         System.out.println("Warmed up ...");
+        MessageQueue warm = new MessageQueue(false);
         for (int j = 0; j < msgCount; j++) {
             msgs[j] = new NatsMessage("a");
+            warm.push(msgs[j]);
         }
 
         System.out.println("Starting tests ...");

--- a/src/test/java/io/nats/client/impl/PingTests.java
+++ b/src/test/java/io/nats/client/impl/PingTests.java
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeoutException;
 import org.junit.Test;
 
 import io.nats.client.Connection;
+import io.nats.client.Dispatcher;
 import io.nats.client.Nats;
 import io.nats.client.NatsServerProtocolMock;
 import io.nats.client.NatsTestServer;
@@ -223,6 +224,51 @@ public class PingTests {
                     nc.close();
                     assertTrue("Closed Status", Connection.Status.CLOSED == nc.getStatus());
                 }
+            }
+        }
+    }
+
+
+    @Test
+    public void testMessagesDelayPings() throws IOException, InterruptedException, ExecutionException, TimeoutException {
+        try (NatsTestServer ts = new NatsTestServer(false)) {
+            Options options = new Options.Builder().server(ts.getURI()).
+                                    pingInterval(Duration.ofMillis(200)).build();
+            NatsConnection nc = (NatsConnection) Nats.connect(options);
+            NatsStatistics stats = nc.getNatsStatistics();
+
+            try {
+                final CompletableFuture<Boolean> done = new CompletableFuture<>();
+                assertTrue("Connected Status", Connection.Status.CONNECTED == nc.getStatus());
+
+                Dispatcher d = nc.createDispatcher((msg) -> {
+                    if (msg.getSubject().equals("done")) {
+                        done.complete(Boolean.TRUE);
+                    }
+                });
+
+                d.subscribe("subject");
+                d.subscribe("done");
+                nc.flush(Duration.ofMillis(1000)); // wait for them to go through
+
+                long b4 = stats.getPings();
+                for (int i=0;i<10;i++) {
+                    Thread.sleep(50);
+                    nc.publish("subject", new byte[16]);
+                }
+                long after = stats.getPings();
+                assertTrue("pings hidden", after == b4);
+                nc.publish("done", new byte[16]);
+                nc.flush(Duration.ofMillis(1000)); // wait for them to go through
+                done.get(500, TimeUnit.MILLISECONDS);
+
+                // no more messages, pings should start to go through
+                b4 = stats.getPings();
+                Thread.sleep(500);
+                after = stats.getPings();
+                assertTrue("pings restarted", after > b4);
+            } finally {
+                nc.close();
             }
         }
     }


### PR DESCRIPTION
* [FIXED] - #230 - removed extra executor allocation
* [FIXED] - #231 - found a problem with message ordering when filtering pings on reconnect, caused issues with reconnect in general
* [FIXED] - #226 - added more doc about ping intervals and max ping
* [FIXED] - #224 - resolved a latency problem with windows due to the cost of the message queues spinwait/lock
* [CHANGED] - started support for renaming gnatsd to nats-server, full release isn't done so using gnatsd for tests still